### PR TITLE
fix breaking sshd_config change

### DIFF
--- a/terraform-azurerm-vnet-app/configure-vm-jumpbox-linux.sh
+++ b/terraform-azurerm-vnet-app/configure-vm-jumpbox-linux.sh
@@ -78,8 +78,8 @@ filename=/etc/ssh/sshd_config
 printf "Backing up file '$filename'...\n" >> $log_file
 sudo cp -f "$filename" "$filename.bak"
 printf "Modifying '$filename'...\n" >> $log_file
-sudo sed -i "s/PasswordAuthentication no/PasswordAuthentication yes/" $filename
-sudo sed -i "s/ChallengeResponseAuthentication no/ChallengeResponseAuthentication yes/" $filename
+sudo sed -i "s/#PasswordAuthentication yes/PasswordAuthentication yes/" $filename
+sudo sed -i "s/KbdInteractiveAuthentication no/KbdInteractiveAuthentication yes/" $filename
 diff "$filename.bak" "$filename" >> $log_file
 servicename='sshd'
 printf "Restarting '$servicename'...\n" >> $log_file


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* Fix for issue [jumplinux1 ssh fails with 'Permission denied (publickey)' error](https://github.com/Azure-Samples/azuresandbox/issues/12)

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[ X ] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ X ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
* Provision a new sandbox with latest version of code
* Complete terraform-azrurerm-vnet-app smoke testing,
## What to Check
Verify that the following are valid
* verify that ssh connectivity to jumplinux1 is working


## Other Information
<!-- Add any other helpful information that may be needed here. -->

Format of etc/ssh/sshd_config changed in latest release of Ubuntu 22..04.03 for Azure which caused automation to break.