### PR TITLE
Make AMA unit test resilient to AzureMonitorWindowsAgent cold-start

### DIFF
--- a/modules/vm-mssql-win/scripts/Test-VmMssqlWin.ps1
+++ b/modules/vm-mssql-win/scripts/Test-VmMssqlWin.ps1
@@ -682,23 +682,68 @@ else {
 #   MonAgentCore, MonAgentHost, MonAgentLauncher, MonAgentManager, AMAExtHealthMonitor
 # running from C:\Packages\Plugins\Microsoft.Azure.Monitor.AzureMonitorWindowsAgent\<ver>\.
 # We require MonAgentCore (the data-plane collector) at minimum.
+#
+# After a VM stop/deallocate+start the extension handler restarts AMA asynchronously and
+# does not block VM startup, so MonAgentCore can take up to ~2 min to (re)appear even when
+# AMAExtHealthMonitor (the launcher) is already running. Poll with a bounded wait so the
+# test is resilient to extension cold-start, and on timeout emit diagnostics that
+# distinguish a slow start from a real extension failure.
 try {
-    $amaProcs = Get-Process -ErrorAction SilentlyContinue |
-        Where-Object { $_.Name -match '^(MonAgent|AMAExt)' }
-    $core = $amaProcs | Where-Object { $_.Name -eq 'MonAgentCore' } | Select-Object -First 1
+    $amaRoot = 'C:\Packages\Plugins\Microsoft.Azure.Monitor.AzureMonitorWindowsAgent'
+    $maxWaitSec = 120
+    $sleepSec = 5
+    $sw = [System.Diagnostics.Stopwatch]::StartNew()
+    $core = $null
+    $amaProcs = @()
+    do {
+        $amaProcs = Get-Process -ErrorAction SilentlyContinue |
+            Where-Object {
+                ($_.Name -match '^(MonAgent|AMAExt)') -and
+                ($_.Path -like "$amaRoot\*")
+            }
+        $core = $amaProcs | Where-Object { $_.Name -eq 'MonAgentCore' } | Select-Object -First 1
+        if ($core) { break }
+        if ($sw.Elapsed.TotalSeconds -ge $maxWaitSec) { break }
+        Start-Sleep -Seconds $sleepSec
+    } while ($true)
+    $sw.Stop()
+    $waited = [int]$sw.Elapsed.TotalSeconds
 
     if ($core) {
-        $amaDir = Get-ChildItem 'C:\Packages\Plugins\Microsoft.Azure.Monitor.AzureMonitorWindowsAgent' -Directory -ErrorAction SilentlyContinue |
+        $amaDir = Get-ChildItem $amaRoot -Directory -ErrorAction SilentlyContinue |
             Where-Object { $_.Name -match '^[0-9.]+$' } |
             Sort-Object Name -Descending |
             Select-Object -First 1
         $version = if ($amaDir) { $amaDir.Name } else { 'unknown' }
         $names = ($amaProcs | Select-Object -ExpandProperty Name -Unique) -join ', '
-        Write-TestResult $moduleName 'PASS' "AMA: Running (version $version, processes: $names)"
+        Write-TestResult $moduleName 'PASS' "AMA: Running (version $version, processes: $names, waited ${waited}s)"
         $passed++
     }
     else {
-        Write-TestResult $moduleName 'FAIL' "AMA: MonAgentCore process not running (found: $(($amaProcs | Select-Object -ExpandProperty Name -Unique) -join ', '))"
+        $found = ($amaProcs | Select-Object -ExpandProperty Name -Unique) -join ', '
+        if ([string]::IsNullOrEmpty($found)) { $found = '<none>' }
+        $uptime = 'unknown'
+        try {
+            $boot = (Get-CimInstance Win32_OperatingSystem -ErrorAction Stop).LastBootUpTime
+            $uptime = '{0:N0}s' -f ((Get-Date) - $boot).TotalSeconds
+        } catch {}
+        $extStatus = 'no status file'
+        try {
+            $statusFile = Get-ChildItem $amaRoot -Directory -ErrorAction Stop |
+                Where-Object { $_.Name -match '^[0-9.]+$' } |
+                Sort-Object Name -Descending |
+                Select-Object -First 1 |
+                ForEach-Object { Get-ChildItem (Join-Path $_.FullName 'Status') -Filter '*.status' -ErrorAction SilentlyContinue } |
+                Sort-Object LastWriteTime -Descending |
+                Select-Object -First 1
+            if ($statusFile) {
+                $statusJson = Get-Content $statusFile.FullName -Raw | ConvertFrom-Json
+                $s = $statusJson.status.status
+                $m = $statusJson.status.formattedMessage.message
+                $extStatus = "status=$s message=$m"
+            }
+        } catch { $extStatus = "status file error: $_" }
+        Write-TestResult $moduleName 'FAIL' "AMA: MonAgentCore not running after ${waited}s (found: $found, vm_uptime=$uptime, extension: $extStatus)"
         $failed++
     }
 }

--- a/modules/vnet-app/scripts/Test-VnetApp.ps1
+++ b/modules/vnet-app/scripts/Test-VnetApp.ps1
@@ -398,23 +398,68 @@ else {
 #   MonAgentCore, MonAgentHost, MonAgentLauncher, MonAgentManager, AMAExtHealthMonitor
 # running from C:\Packages\Plugins\Microsoft.Azure.Monitor.AzureMonitorWindowsAgent\<ver>\.
 # We require MonAgentCore (the data-plane collector) at minimum.
+#
+# After a VM stop/deallocate+start the extension handler restarts AMA asynchronously and
+# does not block VM startup, so MonAgentCore can take up to ~2 min to (re)appear even when
+# AMAExtHealthMonitor (the launcher) is already running. Poll with a bounded wait so the
+# test is resilient to extension cold-start, and on timeout emit diagnostics that
+# distinguish a slow start from a real extension failure.
 try {
-    $amaProcs = Get-Process -ErrorAction SilentlyContinue |
-        Where-Object { $_.Name -match '^(MonAgent|AMAExt)' }
-    $core = $amaProcs | Where-Object { $_.Name -eq 'MonAgentCore' } | Select-Object -First 1
+    $amaRoot = 'C:\Packages\Plugins\Microsoft.Azure.Monitor.AzureMonitorWindowsAgent'
+    $maxWaitSec = 120
+    $sleepSec = 5
+    $sw = [System.Diagnostics.Stopwatch]::StartNew()
+    $core = $null
+    $amaProcs = @()
+    do {
+        $amaProcs = Get-Process -ErrorAction SilentlyContinue |
+            Where-Object {
+                ($_.Name -match '^(MonAgent|AMAExt)') -and
+                ($_.Path -like "$amaRoot\*")
+            }
+        $core = $amaProcs | Where-Object { $_.Name -eq 'MonAgentCore' } | Select-Object -First 1
+        if ($core) { break }
+        if ($sw.Elapsed.TotalSeconds -ge $maxWaitSec) { break }
+        Start-Sleep -Seconds $sleepSec
+    } while ($true)
+    $sw.Stop()
+    $waited = [int]$sw.Elapsed.TotalSeconds
 
     if ($core) {
-        $amaDir = Get-ChildItem 'C:\Packages\Plugins\Microsoft.Azure.Monitor.AzureMonitorWindowsAgent' -Directory -ErrorAction SilentlyContinue |
+        $amaDir = Get-ChildItem $amaRoot -Directory -ErrorAction SilentlyContinue |
             Where-Object { $_.Name -match '^[0-9.]+$' } |
             Sort-Object Name -Descending |
             Select-Object -First 1
         $version = if ($amaDir) { $amaDir.Name } else { 'unknown' }
         $names = ($amaProcs | Select-Object -ExpandProperty Name -Unique) -join ', '
-        Write-TestResult $moduleName 'PASS' "AMA: Running (version $version, processes: $names)"
+        Write-TestResult $moduleName 'PASS' "AMA: Running (version $version, processes: $names, waited ${waited}s)"
         $passed++
     }
     else {
-        Write-TestResult $moduleName 'FAIL' "AMA: MonAgentCore process not running (found: $(($amaProcs | Select-Object -ExpandProperty Name -Unique) -join ', '))"
+        $found = ($amaProcs | Select-Object -ExpandProperty Name -Unique) -join ', '
+        if ([string]::IsNullOrEmpty($found)) { $found = '<none>' }
+        $uptime = 'unknown'
+        try {
+            $boot = (Get-CimInstance Win32_OperatingSystem -ErrorAction Stop).LastBootUpTime
+            $uptime = '{0:N0}s' -f ((Get-Date) - $boot).TotalSeconds
+        } catch {}
+        $extStatus = 'no status file'
+        try {
+            $statusFile = Get-ChildItem $amaRoot -Directory -ErrorAction Stop |
+                Where-Object { $_.Name -match '^[0-9.]+$' } |
+                Sort-Object Name -Descending |
+                Select-Object -First 1 |
+                ForEach-Object { Get-ChildItem (Join-Path $_.FullName 'Status') -Filter '*.status' -ErrorAction SilentlyContinue } |
+                Sort-Object LastWriteTime -Descending |
+                Select-Object -First 1
+            if ($statusFile) {
+                $statusJson = Get-Content $statusFile.FullName -Raw | ConvertFrom-Json
+                $s = $statusJson.status.status
+                $m = $statusJson.status.formattedMessage.message
+                $extStatus = "status=$s message=$m"
+            }
+        } catch { $extStatus = "status file error: $_" }
+        Write-TestResult $moduleName 'FAIL' "AMA: MonAgentCore not running after ${waited}s (found: $found, vm_uptime=$uptime, extension: $extStatus)"
         $failed++
     }
 }

--- a/modules/vnet-shared/scripts/Test-VnetShared.ps1
+++ b/modules/vnet-shared/scripts/Test-VnetShared.ps1
@@ -126,27 +126,68 @@ else {
 #   MonAgentCore, MonAgentHost, MonAgentLauncher, MonAgentManager, AMAExtHealthMonitor
 # running from C:\Packages\Plugins\Microsoft.Azure.Monitor.AzureMonitorWindowsAgent\<ver>\.
 # We require MonAgentCore (the data-plane collector) at minimum.
+#
+# After a VM stop/deallocate+start the extension handler restarts AMA asynchronously and
+# does not block VM startup, so MonAgentCore can take up to ~2 min to (re)appear even when
+# AMAExtHealthMonitor (the launcher) is already running. Poll with a bounded wait so the
+# test is resilient to extension cold-start, and on timeout emit diagnostics that
+# distinguish a slow start from a real extension failure.
 try {
-    $amaProcs = Get-Process -ErrorAction SilentlyContinue |
-        Where-Object {
-            ($_.Name -match '^(MonAgent|AMAExt)') -and
-            ($_.Path -like 'C:\Packages\Plugins\Microsoft.Azure.Monitor.AzureMonitorWindowsAgent\*')
-        }
-
-    $core = $amaProcs | Where-Object { $_.Name -eq 'MonAgentCore' } | Select-Object -First 1
+    $amaRoot = 'C:\Packages\Plugins\Microsoft.Azure.Monitor.AzureMonitorWindowsAgent'
+    $maxWaitSec = 120
+    $sleepSec = 5
+    $sw = [System.Diagnostics.Stopwatch]::StartNew()
+    $core = $null
+    $amaProcs = @()
+    do {
+        $amaProcs = Get-Process -ErrorAction SilentlyContinue |
+            Where-Object {
+                ($_.Name -match '^(MonAgent|AMAExt)') -and
+                ($_.Path -like "$amaRoot\*")
+            }
+        $core = $amaProcs | Where-Object { $_.Name -eq 'MonAgentCore' } | Select-Object -First 1
+        if ($core) { break }
+        if ($sw.Elapsed.TotalSeconds -ge $maxWaitSec) { break }
+        Start-Sleep -Seconds $sleepSec
+    } while ($true)
+    $sw.Stop()
+    $waited = [int]$sw.Elapsed.TotalSeconds
 
     if ($core) {
-        $amaDir = Get-ChildItem 'C:\Packages\Plugins\Microsoft.Azure.Monitor.AzureMonitorWindowsAgent' -Directory -ErrorAction SilentlyContinue |
+        $amaDir = Get-ChildItem $amaRoot -Directory -ErrorAction SilentlyContinue |
             Where-Object { $_.Name -match '^[0-9.]+$' } |
             Sort-Object Name -Descending |
             Select-Object -First 1
         $version = if ($amaDir) { $amaDir.Name } else { 'unknown' }
         $names = ($amaProcs | Select-Object -ExpandProperty Name -Unique) -join ', '
-        Write-TestResult $moduleName 'PASS' "AMA: Running (version $version, processes: $names)"
+        Write-TestResult $moduleName 'PASS' "AMA: Running (version $version, processes: $names, waited ${waited}s)"
         $passed++
     }
     else {
-        Write-TestResult $moduleName 'FAIL' "AMA: MonAgentCore process not running (found: $(($amaProcs | Select-Object -ExpandProperty Name -Unique) -join ', '))"
+        $found = ($amaProcs | Select-Object -ExpandProperty Name -Unique) -join ', '
+        if ([string]::IsNullOrEmpty($found)) { $found = '<none>' }
+        $uptime = 'unknown'
+        try {
+            $boot = (Get-CimInstance Win32_OperatingSystem -ErrorAction Stop).LastBootUpTime
+            $uptime = '{0:N0}s' -f ((Get-Date) - $boot).TotalSeconds
+        } catch {}
+        $extStatus = 'no status file'
+        try {
+            $statusFile = Get-ChildItem $amaRoot -Directory -ErrorAction Stop |
+                Where-Object { $_.Name -match '^[0-9.]+$' } |
+                Sort-Object Name -Descending |
+                Select-Object -First 1 |
+                ForEach-Object { Get-ChildItem (Join-Path $_.FullName 'Status') -Filter '*.status' -ErrorAction SilentlyContinue } |
+                Sort-Object LastWriteTime -Descending |
+                Select-Object -First 1
+            if ($statusFile) {
+                $statusJson = Get-Content $statusFile.FullName -Raw | ConvertFrom-Json
+                $s = $statusJson.status.status
+                $m = $statusJson.status.formattedMessage.message
+                $extStatus = "status=$s message=$m"
+            }
+        } catch { $extStatus = "status file error: $_" }
+        Write-TestResult $moduleName 'FAIL' "AMA: MonAgentCore not running after ${waited}s (found: $found, vm_uptime=$uptime, extension: $extStatus)"
         $failed++
     }
 }


### PR DESCRIPTION
Closes #423.

## What changed

Adds a bounded-wait poll and on-failure diagnostics to the AMA process assertion in all three Windows test scripts:

- `modules/vnet-shared/scripts/Test-VnetShared.ps1`
- `modules/vnet-app/scripts/Test-VnetApp.ps1`
- `modules/vm-mssql-win/scripts/Test-VmMssqlWin.ps1`

### Behavior

- Polls for `MonAgentCore` up to **120 s** (5 s sleep between attempts) before declaring failure.
- Treats "only `AMAExtHealthMonitor` present" as still-starting during the wait window. The launcher's presence is positive evidence the extension handler is alive and (re)spawning child agents.
- On PASS, appends elapsed wait time to the message (e.g. `AMA: Running (version 1.41.2, processes: ..., waited 35s)`) so transient slow starts remain visible.
- On final timeout, the FAIL message now includes:
  - VM uptime since last boot.
  - The latest extension HandlerStatus from `C:\Packages\Plugins\Microsoft.Azure.Monitor.AzureMonitorWindowsAgent\<ver>\Status\*.status` (`status` + `formattedMessage`).
  - The list of AMA-related processes actually found.

Return semantics preserved — still exactly one `Write-TestResult` PASS or FAIL row per test, so `[SUMMARY] Passed/Failed/Total` counts are unchanged.

Also adds the existing Path filter (`C:\Packages\Plugins\Microsoft.Azure.Monitor.AzureMonitorWindowsAgent\*`) to the `vnet-app` and `vm-mssql-win` blocks for consistency with `vnet-shared` — safer match in case anything else on the box ever starts with `MonAgent`.

## Why

`scripts/Invoke-UnitTests.ps1` deliberately stops/deallocates and restarts `mssqlwin1` before its tests, then polls for SQL Server readiness only. The AzureMonitorWindowsAgent extension restarts asynchronously and does not block VM startup, so the test would fire while `AMAExtHealthMonitor` was up but `MonAgentCore` had not yet been relaunched. Symptom: `[FAIL] AMA: MonAgentCore process not running (found: AMAExtHealthMonitor)`. See #423 for the full root cause.

The `vnet-shared`/`vnet-app` copies of the same code pass today only because their VMs are not restarted by the orchestrator. Applying the same fix everywhere prevents the same race from resurfacing if anyone adds a restart step later.

## Validation

- `pwsh -NoProfile -Command [scriptblock]::Create(...)` parse check passes on all three edited scripts.
- **Not yet re-tested end-to-end** against a freshly redeployed sandbox — this PR should be paired with a manual rerun of `Invoke-UnitTests.ps1 -Module vm_mssql_win` after deploy to confirm the test now passes through the stop/start cycle.

## Out of scope

- Separate sudo pre-validation bug in `Invoke-UnitTests.ps1` that broke the P2S VPN integration test (`sudo: a terminal is required to read the password`).
- Adding an orchestrator-side AMA readiness wait in `Invoke-UnitTests.ps1` (defense-in-depth follow-up).
- Refactoring the three AMA blocks into a shared helper (test scripts run remotely via `azurerm_virtual_machine_run_command` and can't dot-source).