### PR TITLE
Fix vwan integration test hanging after launching OpenVPN (#445)

### DIFF
--- a/scripts/Test-Integration-VwanConnectivity.ps1
+++ b/scripts/Test-Integration-VwanConnectivity.ps1
@@ -387,7 +387,11 @@ key $clientKeyPath
         # Run openvpn in background, capturing stderr separately for diagnostics.
         # The user shell (bash) handles backgrounding/redirection; only openvpn is elevated
         # so a command-scoped NOPASSWD sudoers entry (not 'sudo bash') is sufficient.
-        & bash -c "sudo openvpn --config '$ovpnConfigPath' --log '$ovpnLogPath' --writepid '$ovpnPidPath' 2>'$ovpnStderrPath' </dev/null &"
+        # All three standard streams must be redirected: openvpn is a long-lived daemon,
+        # and if stdout stays attached to the pipe created by PowerShell's call operator (&),
+        # PowerShell blocks indefinitely waiting for EOF that never arrives. openvpn already
+        # writes its output to --log, so stdout is safely discarded here.
+        & bash -c "sudo openvpn --config '$ovpnConfigPath' --log '$ovpnLogPath' --writepid '$ovpnPidPath' 1>/dev/null 2>'$ovpnStderrPath' </dev/null &"
         $ovpnExitCode = $LASTEXITCODE
     }
     else {


### PR DESCRIPTION
## Summary

Fixes #445.

`scripts/Test-Integration-VwanConnectivity.ps1` launched openvpn in the background like this:

```powershell
& bash -c "sudo openvpn --config '$ovpnConfigPath' --log '$ovpnLogPath' --writepid '$ovpnPidPath' 2>'$ovpnStderrPath' </dev/null &"
```

It redirected **stdin** (`</dev/null`) and **stderr** (`2>...`) but **not stdout**. The long-lived `openvpn` daemon inherited the stdout pipe created by PowerShell's call operator (`&`), and PowerShell blocks until that pipe reaches EOF — which never happens for a persistent daemon. The VPN tunnel established correctly (`Initialization Sequence Completed`, `tun0` up), but the orchestrator never advanced past launching it, hanging the entire `Invoke-UnitTests.ps1` run indefinitely (observed ~4 hours before manual termination).

## Change

Redirect stdout to `/dev/null` as well:

```powershell
& bash -c "sudo openvpn ... 1>/dev/null 2>'$ovpnStderrPath' </dev/null &"
```

openvpn already writes its output to the file passed via `--log`, so no diagnostics are lost — stderr is still captured separately for failure reporting, and the bounded 120s tunnel-establishment poll loop reads from the `--log` file as before.

## Testing

- `Test-Integration-VwanConnectivity.ps1` parses cleanly (`[Parser]::ParseFile` reports no errors).
- The NOPASSWD sudoers scoping is unchanged: only `openvpn` is elevated (`bash -c "sudo openvpn ..."`, not `sudo bash`), so the command-scoped drop-in still applies.

## Notes

Single-line, surgical change plus an explanatory comment. Please review before merging — do not auto-merge.