### PR TITLE
Update Terraform required_version to ~> 1.15.6

### DIFF
--- a/extras/configurations/rg-devops-iac/modules/vm-jumpbox-linux/terraform.tf
+++ b/extras/configurations/rg-devops-iac/modules/vm-jumpbox-linux/terraform.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 1.15.5"
+  required_version = "~> 1.15.6"
 
   required_providers {
     azurerm = {

--- a/extras/configurations/rg-devops-iac/terraform.tf
+++ b/extras/configurations/rg-devops-iac/terraform.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 1.15.5"
+  required_version = "~> 1.15.6"
 
   required_providers {
     azapi = {

--- a/extras/modules/ai-foundry/terraform.tf
+++ b/extras/modules/ai-foundry/terraform.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 1.15.5"
+  required_version = "~> 1.15.6"
 
   required_providers {
     azapi = {

--- a/extras/modules/avd/terraform.tf
+++ b/extras/modules/avd/terraform.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 1.15.5"
+  required_version = "~> 1.15.6"
 
   required_providers {
     azurerm = {

--- a/extras/modules/petstore/terraform.tf
+++ b/extras/modules/petstore/terraform.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 1.15.5"
+  required_version = "~> 1.15.6"
 
   required_providers {
     azurerm = {

--- a/extras/modules/retired/vm-devops-win/terraform.tf
+++ b/extras/modules/retired/vm-devops-win/terraform.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 1.15.5"
+  required_version = "~> 1.15.6"
 
   required_providers {
     azurerm = {

--- a/extras/modules/vnet-onprem/terraform.tf
+++ b/extras/modules/vnet-onprem/terraform.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 1.15.5"
+  required_version = "~> 1.15.6"
 
   required_providers {
     azurerm = {

--- a/modules/mssql/terraform.tf
+++ b/modules/mssql/terraform.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 1.15.5"
+  required_version = "~> 1.15.6"
 
   required_providers {
     azurerm = {

--- a/modules/mysql/terraform.tf
+++ b/modules/mysql/terraform.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 1.15.5"
+  required_version = "~> 1.15.6"
 
   required_providers {
     azurerm = {

--- a/modules/vm-jumpbox-linux/terraform.tf
+++ b/modules/vm-jumpbox-linux/terraform.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 1.15.5"
+  required_version = "~> 1.15.6"
 
   required_providers {
     azurerm = {

--- a/modules/vm-mssql-win/terraform.tf
+++ b/modules/vm-mssql-win/terraform.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 1.15.5"
+  required_version = "~> 1.15.6"
 
   required_providers {
     azurerm = {

--- a/modules/vnet-app/terraform.tf
+++ b/modules/vnet-app/terraform.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 1.15.5"
+  required_version = "~> 1.15.6"
 
   required_providers {
     azurerm = {

--- a/modules/vnet-shared/terraform.tf
+++ b/modules/vnet-shared/terraform.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 1.15.5"
+  required_version = "~> 1.15.6"
 
   required_providers {
     azurerm = {

--- a/modules/vwan/terraform.tf
+++ b/modules/vwan/terraform.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 1.15.5"
+  required_version = "~> 1.15.6"
 
   required_providers {
     azurerm = {

--- a/terraform.tf
+++ b/terraform.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 1.15.5"
+  required_version = "~> 1.15.6"
 
   required_providers {
     azuread = {


### PR DESCRIPTION
## Summary

Bumps the pinned Terraform CLI version from `~> 1.15.5` to `~> 1.15.6` to match the new CLI release (v1.15.6).

## Changes

Updated `required_version` in `required_version` blocks across all `terraform.tf` files:

- Root configuration (`terraform.tf`)
- All base modules (`modules/**`)
- All extra modules and standalone configurations (`extras/**`)

15 files changed, version pin only — no functional changes.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>