### PR TITLE
ci(terraform): add terraform validate job

### DIFF
--- a/.github/workflows/ci-terraform.yml
+++ b/.github/workflows/ci-terraform.yml
@@ -59,3 +59,34 @@ jobs:
       # Recursively lints the root module and every child module.
       - name: Run tflint
         run: tflint --recursive
+
+  validate:
+    name: terraform validate
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # Each entry is a root configuration (has its own provider blocks).
+        # Child modules under modules/ and extras/modules/ are validated
+        # transitively when the root configs that call them are validated.
+        dir:
+          - .
+          - extras/configurations/rg-devops-iac
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: hashicorp/setup-terraform@v3
+        with:
+          # Matches required_version (~> 1.15.6) in terraform.tf.
+          terraform_version: 1.15.6
+          terraform_wrapper: false
+
+      # -backend=false downloads providers/initializes modules without
+      # configuring remote state, so validation needs no Azure credentials.
+      - name: terraform init (no backend)
+        run: terraform init -backend=false -input=false
+        working-directory: ${{ matrix.dir }}
+
+      - name: terraform validate
+        run: terraform validate -no-color
+        working-directory: ${{ matrix.dir }}


### PR DESCRIPTION
Part of #466 (candidate 1 of 4).

Adds a credential-free `validate` job to `ci-terraform.yml`:

- Uses a matrix over the two root configurations (repo root `.` and `extras/configurations/rg-devops-iac`).
- Runs `terraform init -backend=false -input=false` then `terraform validate -no-color` in each.
- `-backend=false` means **no Azure credentials** are required (no remote state configured); providers and modules are still downloaded so semantic validation runs.
- Child modules under `modules/` and `extras/modules/` are validated transitively via the root configs that call them.

Verified locally: both configurations report `Success! The configuration is valid.`

Refs #466.