### PR TITLE
ci(secrets): add gitleaks secret scanning workflow

### DIFF
--- a/.github/workflows/ci-secrets.yml
+++ b/.github/workflows/ci-secrets.yml
@@ -1,0 +1,49 @@
+# CI: secret scanning (gitleaks).
+# Catches credentials accidentally committed to the tree, complementing the
+# .gitignore rules for *.tfvars, *.pem, *.pfx and *.tfstate*.
+# Runs on every pull request targeting vnext and on pushes to vnext.
+name: ci-secrets
+
+on:
+  pull_request:
+    branches: [vnext]
+  push:
+    branches: [vnext]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-secrets-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  gitleaks:
+    name: gitleaks
+    runs-on: ubuntu-latest
+    env:
+      # Pinned for deterministic, reproducible scans. Bump intentionally.
+      GITLEAKS_VERSION: 8.30.1
+    steps:
+      - uses: actions/checkout@v4
+
+      # Download the pinned gitleaks release directly (no Marketplace action,
+      # which would require a GITLEAKS_LICENSE for organization repos) and
+      # verify its checksum before use.
+      - name: Install gitleaks
+        run: |
+          set -euo pipefail
+          base="https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}"
+          tarball="gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz"
+          curl -fsSL "$base/$tarball" -o "$tarball"
+          curl -fsSL "$base/gitleaks_${GITLEAKS_VERSION}_checksums.txt" -o checksums.txt
+          grep " $tarball\$" checksums.txt | sha256sum -c -
+          tar -xzf "$tarball" gitleaks
+          ./gitleaks version
+
+      # Scan the checked-out working tree (`dir`) so secrets present in the PR's
+      # files are caught regardless of git history depth. --redact keeps secret
+      # values out of the logs; gitleaks exits non-zero when any leak is found.
+      - name: Run gitleaks
+        run: ./gitleaks dir . --redact --verbose --no-banner


### PR DESCRIPTION
Part of #466 (candidate 2 of 4).

Adds a new credential-free `ci-secrets` workflow (gitleaks) that scans PRs and pushes to `vnext` for accidentally committed secrets, complementing the existing `.gitignore` rules for `*.tfvars`, `*.pem`, `*.pfx`, `*.tfstate*`.

### Approach
- Downloads a **pinned** gitleaks release (`v8.30.1`) and **verifies its SHA-256 checksum** before running — deterministic and reproducible.
- Uses the release **binary directly** instead of `gitleaks/gitleaks-action`, which requires a `GITLEAKS_LICENSE` secret for organization-owned repos (Azure-Samples). This keeps the check credential-free.
- Scans the checked-out tree with `gitleaks dir . --redact`; `--redact` keeps any matched values out of the logs. In a fresh CI checkout the tree contains only tracked files, so this effectively scans what's committed.
- Deliberately **does not allowlist** `terraform.tfstate*` — if such a file is ever force-committed, that's a real leak we want surfaced.

### Verification
Ran the exact download + checksum + scan steps locally:
- Checksum verification passes; `gitleaks version` = 8.30.1.
- Scanning a clean export of the committed tree (`git archive HEAD`) → **`no leaks found`, exit 0**.

Refs #466.