### PR TITLE
ci(docs): add scheduled external link check (lychee, weekly)

### DIFF
--- a/.github/workflows/ci-docs-external-links.yml
+++ b/.github/workflows/ci-docs-external-links.yml
@@ -1,0 +1,66 @@
+# CI: external link checking (lychee, scheduled).
+# The PR-time ci-docs job runs lychee in --offline mode (internal/relative
+# links only) for determinism. This job additionally checks *external* URLs,
+# but only on a nightly schedule (and on demand) so flaky/slow external
+# requests never block pull requests. Broken external links are surfaced by
+# opening/updating a tracking issue.
+name: ci-docs-external-links
+
+on:
+  schedule:
+    # 07:00 UTC daily.
+    - cron: "0 7 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  # Needed to open/update the tracking issue when external links break.
+  issues: write
+
+concurrency:
+  group: ci-docs-external-links-${{ github.workflow }}
+  cancel-in-progress: true
+
+jobs:
+  lychee-external:
+    name: lychee (external links)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      # Checks every link, including external URLs (no --offline). Caching and
+      # retries reduce transient failures from rate-limited/slow hosts.
+      # fail: false keeps the step green so the issue-reporting step below can
+      # run; the broken-link signal is taken from the step's exit_code output.
+      - name: Link check (external)
+        id: lychee
+        uses: lycheeverse/lychee-action@v2
+        with:
+          args: >-
+            --no-progress
+            --cache
+            --max-cache-age 1d
+            --max-retries 3
+            './**/*.md'
+          output: ./lychee-report.md
+          format: markdown
+          fail: false
+
+      - name: Report broken links via tracking issue
+        if: steps.lychee.outputs.exit_code != 0
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TITLE: "Broken external links detected by scheduled lychee run"
+        run: |
+          set -euo pipefail
+          body_file=lychee-report.md
+          [ -f "$body_file" ] || echo "lychee reported broken links (no report file produced)." > "$body_file"
+          existing=$(gh issue list --state open --search "$TITLE in:title" \
+            --json number --jq '.[0].number // empty')
+          if [ -n "$existing" ]; then
+            gh issue comment "$existing" --body-file "$body_file"
+            echo "Updated existing tracking issue #$existing."
+          else
+            gh issue create --title "$TITLE" --body-file "$body_file"
+            echo "Opened new tracking issue."
+          fi

--- a/.github/workflows/ci-docs-external-links.yml
+++ b/.github/workflows/ci-docs-external-links.yml
@@ -1,15 +1,16 @@
 # CI: external link checking (lychee, scheduled).
 # The PR-time ci-docs job runs lychee in --offline mode (internal/relative
 # links only) for determinism. This job additionally checks *external* URLs,
-# but only on a nightly schedule (and on demand) so flaky/slow external
+# but only on a weekly schedule (and on demand) so flaky/slow external
 # requests never block pull requests. Broken external links are surfaced by
 # opening/updating a tracking issue.
 name: ci-docs-external-links
 
 on:
   schedule:
-    # 07:00 UTC daily.
-    - cron: "0 7 * * *"
+    # Weekly, Monday 08:00 UTC — matches the dependabot terraform update
+    # cadence (.github/dependabot.yml) so maintenance lands together.
+    - cron: "0 8 * * 1"
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
Part of #466 (candidate 4 of 4 — final).

Adds a new `ci-docs-external-links` workflow that checks **external** URLs in the docs with lychee, on a **weekly schedule** (plus `workflow_dispatch`) rather than on PRs — so flaky/slow external hosts never block pull requests, while broken external links are still surfaced.

### Design
- **Triggers:** `schedule` (`0 8 * * 1` — **Monday 08:00 UTC**, matching the dependabot terraform update cadence in `.github/dependabot.yml` so maintenance lands together) + `workflow_dispatch`. Intentionally **no** `pull_request`/`push` triggers — the existing `ci-docs` job keeps running lychee in `--offline` mode (internal/relative links only) on PRs for determinism.
- **Checks external URLs:** same `./**/*.md` glob as `ci-docs`, without `--offline`. Adds `--cache --max-cache-age 1d --max-retries 3` to reduce transient/rate-limit failures.
- **Surfacing failures without blocking:** the lychee step runs with `fail: false` and its `exit_code` output drives a follow-up step that **opens or updates a single tracking issue** (idempotent — searches by title) using the built-in `github.token`. Adds only `issues: write`; otherwise read-only.

### Verification
- YAML parses; `actionlint` **+ shellcheck** on the `run:` step → **exit 0 (no findings)**.
- Confirmed the `lychee-action@v2` inputs used (`args`, `output`, `format`, `fail`) and the `exit_code` output against the action's `action.yml`.

Note: this workflow only runs on schedule/dispatch, so it will not execute on this PR; the standard PR checks still apply.

Closes #466.