### PR TITLE
Add ShellCheck CI for bash scripts

### DIFF
--- a/.github/workflows/ci-bash.yml
+++ b/.github/workflows/ci-bash.yml
@@ -1,0 +1,62 @@
+# CI: bash static analysis (ShellCheck).
+# Lints every *.sh in the tree, failing on warning- and error-severity findings.
+# The bash analogue of ci-powershell.yml (PSScriptAnalyzer). Rule configuration
+# (per-rule excludes, external-sources) lives in the repo-root .shellcheckrc; the
+# warning+error gate is applied via the --severity flag below. Developers can run
+# the identical check locally with scripts/Invoke-ShellCheck.sh.
+# Runs on every pull request targeting vnext and on pushes to vnext.
+name: ci-bash
+
+on:
+  pull_request:
+    branches: [vnext]
+  push:
+    branches: [vnext]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-bash-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  shellcheck:
+    name: ShellCheck
+    runs-on: ubuntu-latest
+    env:
+      # Pinned for deterministic, reproducible scans. Bump intentionally.
+      SHELLCHECK_VERSION: 0.10.0
+      # SHA256 of shellcheck-v${SHELLCHECK_VERSION}.linux.x86_64.tar.xz from the
+      # official koalaman/shellcheck release. Update when bumping the version.
+      SHELLCHECK_SHA256: 6c881ab0698e4e6ea235245f22832860544f17ba386442fe7e9d629f8cbedf87
+    steps:
+      - uses: actions/checkout@v4
+
+      # Download the pinned ShellCheck release directly (no Marketplace action) and
+      # verify its checksum before use, mirroring the gitleaks install in ci-secrets.yml.
+      - name: Install ShellCheck
+        run: |
+          set -euo pipefail
+          tarball="shellcheck-v${SHELLCHECK_VERSION}.linux.x86_64.tar.xz"
+          url="https://github.com/koalaman/shellcheck/releases/download/v${SHELLCHECK_VERSION}/${tarball}"
+          curl -fsSL "$url" -o "$tarball"
+          echo "${SHELLCHECK_SHA256}  ${tarball}" | sha256sum -c -
+          tar -xJf "$tarball" "shellcheck-v${SHELLCHECK_VERSION}/shellcheck"
+          install -m 0755 "shellcheck-v${SHELLCHECK_VERSION}/shellcheck" /usr/local/bin/shellcheck
+          shellcheck --version
+
+      # Lint every *.sh in the tree (excluding .git). Severity is set here; other
+      # rule config comes from the repo-root .shellcheckrc. ShellCheck exits
+      # non-zero when any finding at or above the threshold is reported.
+      - name: Run ShellCheck
+        run: |
+          set -euo pipefail
+          mapfile -d '' -t scripts < <(find . -name '*.sh' -not -path './.git/*' -print0)
+          printf 'Linting %d shell script(s)...\n' "${#scripts[@]}"
+          if ! shellcheck --severity=warning "${scripts[@]}"; then
+            echo "::error::ShellCheck found warning/error-severity issue(s)."
+            exit 1
+          fi
+          echo 'ShellCheck: no issues found.'

--- a/.shellcheckrc
+++ b/.shellcheckrc
@@ -1,0 +1,17 @@
+# ShellCheck configuration for this repository.
+#
+# Single source of truth for the bash linting gate: both the ci-bash GitHub
+# Actions workflow and the local scripts/Invoke-ShellCheck.sh wrapper read this
+# file, so local results match CI exactly. This is the bash analogue of
+# PSScriptAnalyzerSettings.psd1 for the PowerShell CI.
+#
+# NOTE on severity: ShellCheck does not honor a `severity=` directive in
+# .shellcheckrc (it is a CLI-only flag), so the warning+error gate is applied via
+# `--severity=warning` in both the workflow and Invoke-ShellCheck.sh. Keep that
+# value in sync if it ever changes. Per-rule `disable=`/`enable=` exclusions, when
+# needed, belong here so CI and local runs share them.
+
+# Do not follow `source`/`.` into other files during analysis. The scripts here
+# are standalone; following sourced files would require resolving paths that only
+# exist on the provisioned VMs/runners.
+external-sources=false

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -89,6 +89,7 @@ Pull requests targeting `vnext` (and pushes to `vnext`) automatically run lightw
 | `ci-docs` | `markdownlint-cli2` (Markdown style) and `lychee` (internal/relative link checker, offline) | [`.markdownlint.jsonc`](.markdownlint.jsonc), [`.markdownlint-cli2.jsonc`](.markdownlint-cli2.jsonc) |
 | `ci-terraform` | `terraform fmt -check -recursive` and `tflint --recursive` | [`.tflint.hcl`](.tflint.hcl) |
 | `ci-powershell` | `PSScriptAnalyzer` over all PowerShell scripts | [`PSScriptAnalyzerSettings.psd1`](PSScriptAnalyzerSettings.psd1) |
+| `ci-bash` | `ShellCheck` over all `*.sh` scripts (fails on warning + error severity) | [`.shellcheckrc`](.shellcheckrc) |
 
 To reproduce the checks locally before opening a PR:
 
@@ -103,9 +104,16 @@ tflint --init && tflint --recursive
 
 # PowerShell (PowerShell 7.x with the PSScriptAnalyzer module)
 pwsh -NoProfile -Command "Invoke-ScriptAnalyzer -Path . -Recurse -Settings ./PSScriptAnalyzerSettings.psd1 -Severity Error,Warning"
+
+# Bash (requires ShellCheck on PATH:
+#   sudo apt-get install -y shellcheck  |  brew install shellcheck  |
+#   download a release from https://github.com/koalaman/shellcheck/releases)
+./scripts/Invoke-ShellCheck.sh
 ```
 
 The PSScriptAnalyzer settings file excludes a small set of rules that conflict with intentional patterns in this deployment-automation codebase (for example, `Write-Host` console output, the project's own `Write-Log` helper, and plaintext-to-`SecureString` conversion required for unattended VM configuration). Each exclusion is documented inline in `PSScriptAnalyzerSettings.psd1`.
+
+`ci-bash` runs ShellCheck at `--severity=warning` (the warning + error gate, mirroring the PowerShell CI). `scripts/Invoke-ShellCheck.sh` runs the identical command locally and shares the repo-root `.shellcheckrc`, so local results match CI exactly. A single documented `# shellcheck disable=SC2024` is applied in `modules/vm-jumpbox-linux/scripts/configure-vm-jumpbox-linux.sh`, where `sudo <cmd> >> $log_file` intentionally elevates only the command while appending to the user-owned log; the justification is recorded inline at the top of that script.
 
 ## Submission Guidelines
 

--- a/extras/configurations/rg-devops-iac/scripts/cleanterraformtemp.sh
+++ b/extras/configurations/rg-devops-iac/scripts/cleanterraformtemp.sh
@@ -3,51 +3,51 @@
 printf "Removing all files matching 'terraform.tfvars'...\n"
 
 find ../. -type f -name 'terraform.tfvars' 
-find ../. -type f -name 'terraform.tfvars' | xargs -r rm
+find ../. -type f -name 'terraform.tfvars' -print0 | xargs -0 -r rm
 
 printf "Removing all files matching 'terraform.tfstate'...\n"
 
 find ../. -type f -name 'terraform.tfstate' 
-find ../. -type f -name 'terraform.tfstate' | xargs -r rm
+find ../. -type f -name 'terraform.tfstate' -print0 | xargs -0 -r rm
 
 printf "Removing all files matching 'terraform.tfstate.backup'...\n"
 
 find ../. -type f -name 'terraform.tfstate.backup' 
-find ../. -type f -name 'terraform.tfstate.backup' | xargs -r rm
+find ../. -type f -name 'terraform.tfstate.backup' -print0 | xargs -0 -r rm
 
 printf "Removing all files matching 'terraform.tfstate.*.backup'...\n"
 
 find ../. -type f -name 'terraform.tfstate.*.backup' 
-find ../. -type f -name 'terraform.tfstate.*.backup' | xargs -r rm
+find ../. -type f -name 'terraform.tfstate.*.backup' -print0 | xargs -0 -r rm
 
 printf "Removing all files and directories matching '.terraform'...\n"
 
 find ../. -type d -name '.terraform'
-find ../. -type d -name '.terraform' | xargs -r rm -r
+find ../. -type d -name '.terraform' -print0 | xargs -0 -r rm -r
 
 printf "Removing all files matching '.terraform.tfstate.lock.info'...\n"
 
 find ../. -type f -name '.terraform.tfstate.lock.info' 
-find ../. -type f -name '.terraform.tfstate.lock.info' | xargs -r rm
+find ../. -type f -name '.terraform.tfstate.lock.info' -print0 | xargs -0 -r rm
 
 printf "Removing all files matching '.terraform.lock.hcl'...\n"
 
 find ../. -type f -name '.terraform.lock.hcl' 
-find ../. -type f -name '.terraform.lock.hcl' | xargs -r rm
+find ../. -type f -name '.terraform.lock.hcl' -print0 | xargs -0 -r rm
 
 printf "Removing all files matching 'sshkeytemp*'...\n"
 
 find ../. -type f -name 'sshkeytemp*' 
-find ../. -type f -name 'sshkeytemp*' | xargs -r rm
+find ../. -type f -name 'sshkeytemp*' -print0 | xargs -0 -r rm
 
 printf "Removing all files matching '*.pem'...\n"
 
 find ../. -type f -name '*.pem' 
-find ../. -type f -name '*.pem' | xargs -r rm
+find ../. -type f -name '*.pem' -print0 | xargs -0 -r rm
 
 printf "Removing all files matching '*.pfx'...\n"
 
 find ../. -type f -name '*.pfx' 
-find ../. -type f -name '*.pfx' | xargs -r rm
+find ../. -type f -name '*.pfx' -print0 | xargs -0 -r rm
 
 exit 0

--- a/modules/vm-jumpbox-linux/scripts/configure-vm-jumpbox-linux.sh
+++ b/modules/vm-jumpbox-linux/scripts/configure-vm-jumpbox-linux.sh
@@ -1,5 +1,13 @@
 #!/bin/bash
 
+# shellcheck disable=SC2024
+# SC2024 (sudo doesn't affect redirects) is intentionally disabled file-wide:
+# throughout this script 'sudo <cmd> >> $log_file' elevates only the command, while
+# the redirect appends to $log_file as the invoking user. That user already owns the
+# log (it is written without sudo elsewhere in this script), so the non-elevated
+# redirect is the desired behavior. Rewriting these as 'sudo tee' would wrongly
+# elevate the log write and change '&>>' stream-capture semantics.
+
 # Note: This code has been tested on Ubuntu 24.04 LTS (Noble Numbat) and will not work on other Linux distros
 
 # Initialize constants

--- a/scripts/Invoke-ShellCheck.sh
+++ b/scripts/Invoke-ShellCheck.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+# Local bash linting pre-check.
+#
+# Runs the exact same ShellCheck command the ci-bash GitHub Actions workflow runs,
+# so developers can reproduce the CI gate locally before pushing. Configuration
+# (severity, etc.) is read from the repository-root .shellcheckrc, which both this
+# script and CI share as the single source of truth.
+#
+# Usage:
+#   ./scripts/Invoke-ShellCheck.sh
+#
+# Requires ShellCheck on PATH:
+#   sudo apt-get install -y shellcheck   # Debian/Ubuntu
+#   brew install shellcheck              # macOS
+#   # or download a pinned release from https://github.com/koalaman/shellcheck/releases
+#
+# Exit code: 0 when no warning/error findings, non-zero otherwise (CI-friendly).
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "$0")/.." && pwd)"
+
+if ! command -v shellcheck > /dev/null 2>&1; then
+    printf "ERROR: 'shellcheck' not found on PATH.\n" >&2
+    printf "Install it with 'sudo apt-get install -y shellcheck', 'brew install shellcheck',\n" >&2
+    printf "or download a release from https://github.com/koalaman/shellcheck/releases.\n" >&2
+    exit 127
+fi
+
+printf "Running ShellCheck (%s)...\n" "$(shellcheck --version | awk '/version:/ {print $2}')"
+
+# Discover every tracked shell script (excluding the .git directory) so newly
+# added scripts are covered automatically. The warning+error gate is set via the
+# --severity flag (ShellCheck ignores a severity directive in .shellcheckrc);
+# other shared config (external-sources, per-rule excludes) comes from .shellcheckrc.
+if find "$repo_root" -name '*.sh' -not -path '*/.git/*' -print0 \
+    | xargs -0 -r shellcheck --severity=warning; then
+    printf "ShellCheck: no warning/error findings.\n"
+else
+    status=$?
+    printf "ShellCheck found issues (exit %d).\n" "$status" >&2
+    exit "$status"
+fi

--- a/scripts/cleanterraformtemp.sh
+++ b/scripts/cleanterraformtemp.sh
@@ -7,61 +7,61 @@ REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 printf "Removing all files matching 'terraform.tfvars'...\n"
 
 find "$REPO_ROOT" -type f -name 'terraform.tfvars' 
-find "$REPO_ROOT" -type f -name 'terraform.tfvars' | xargs -r rm
+find "$REPO_ROOT" -type f -name 'terraform.tfvars' -print0 | xargs -0 -r rm
 
 printf "Removing all files matching 'terraform.tfstate'...\n"
 
 find "$REPO_ROOT" -type f -name 'terraform.tfstate' 
-find "$REPO_ROOT" -type f -name 'terraform.tfstate' | xargs -r rm
+find "$REPO_ROOT" -type f -name 'terraform.tfstate' -print0 | xargs -0 -r rm
 
 printf "Removing all files matching 'terraform.tfstate.backup'...\n"
 
 find "$REPO_ROOT" -type f -name 'terraform.tfstate.backup' 
-find "$REPO_ROOT" -type f -name 'terraform.tfstate.backup' | xargs -r rm
+find "$REPO_ROOT" -type f -name 'terraform.tfstate.backup' -print0 | xargs -0 -r rm
 
 printf "Removing all files matching 'terraform.tfstate.*.backup'...\n"
 
 find "$REPO_ROOT" -type f -name 'terraform.tfstate.*.backup' 
-find "$REPO_ROOT" -type f -name 'terraform.tfstate.*.backup' | xargs -r rm
+find "$REPO_ROOT" -type f -name 'terraform.tfstate.*.backup' -print0 | xargs -0 -r rm
 
 printf "Removing all files and directories matching '.terraform'...\n"
 
 find "$REPO_ROOT" -type d -name '.terraform'
-find "$REPO_ROOT" -type d -name '.terraform' | xargs -r rm -r
+find "$REPO_ROOT" -type d -name '.terraform' -print0 | xargs -0 -r rm -r
 
 printf "Removing all files matching '.terraform.tfstate.lock.info'...\n"
 
 find "$REPO_ROOT" -type f -name '.terraform.tfstate.lock.info' 
-find "$REPO_ROOT" -type f -name '.terraform.tfstate.lock.info' | xargs -r rm
+find "$REPO_ROOT" -type f -name '.terraform.tfstate.lock.info' -print0 | xargs -0 -r rm
 
 printf "Removing all files matching '.terraform.lock.hcl'...\n"
 
 find "$REPO_ROOT" -type f -name '.terraform.lock.hcl' 
-find "$REPO_ROOT" -type f -name '.terraform.lock.hcl' | xargs -r rm
+find "$REPO_ROOT" -type f -name '.terraform.lock.hcl' -print0 | xargs -0 -r rm
 
 printf "Removing all files matching 'sshkeytemp*'...\n"
 
 find "$REPO_ROOT" -type f -name 'sshkeytemp*' 
-find "$REPO_ROOT" -type f -name 'sshkeytemp*' | xargs -r rm
+find "$REPO_ROOT" -type f -name 'sshkeytemp*' -print0 | xargs -0 -r rm
 
 printf "Removing all files matching '*.pem'...\n"
 
 find "$REPO_ROOT" -type f -name '*.pem' 
-find "$REPO_ROOT" -type f -name '*.pem' | xargs -r rm
+find "$REPO_ROOT" -type f -name '*.pem' -print0 | xargs -0 -r rm
 
 printf "Removing all files matching '*.pfx'...\n"
 
 find "$REPO_ROOT" -type f -name '*.pfx' 
-find "$REPO_ROOT" -type f -name '*.pfx' | xargs -r rm
+find "$REPO_ROOT" -type f -name '*.pfx' -print0 | xargs -0 -r rm
 
 printf "Removing all files matching '*.log'...\n"
 
 find "$REPO_ROOT" -type f -name '*.log' 
-find "$REPO_ROOT" -type f -name '*.log' | xargs -r rm
+find "$REPO_ROOT" -type f -name '*.log' -print0 | xargs -0 -r rm
 
 printf "Removing all files matching '*.tfplan'...\n"
 
 find "$REPO_ROOT" -type f -name '*.tfplan' 
-find "$REPO_ROOT" -type f -name '*.tfplan' | xargs -r rm
+find "$REPO_ROOT" -type f -name '*.tfplan' -print0 | xargs -0 -r rm
 
 exit 0


### PR DESCRIPTION
## Summary

Adds CI for bash scripts using **ShellCheck**, mirroring the existing `ci-powershell` (PSScriptAnalyzer) gate. The repo previously had CI for PowerShell, Terraform, docs, and secrets — but bash scripts were unlinted.

## What's included

**New files**
- `.github/workflows/ci-bash.yml` — runs ShellCheck at `--severity=warning` (warning + error gate) over all `*.sh`. Pins ShellCheck `0.10.0` and verifies the release tarball SHA256 (no Marketplace action, mirroring the gitleaks install in `ci-secrets.yml`). Triggers on PR + push to `vnext` + `workflow_dispatch`; uses a `concurrency` group, `contents: read`, and emits `::error::` + `exit 1` on findings.
- `.shellcheckrc` — shared config (single source of truth for CI and local runs).
- `scripts/Invoke-ShellCheck.sh` — local pre-check wrapper that runs the identical command CI runs, with install hints.

**Remediated 40 pre-existing findings** (the gate would otherwise fail on the current tree):
- **22× SC2038** (`find | xargs rm`) in `scripts/cleanterraformtemp.sh` and `extras/configurations/rg-devops-iac/scripts/cleanterraformtemp.sh` → converted to `find … -print0 | xargs -0`.
- **18× SC2024** (`sudo <cmd> >> $log_file`) in `modules/vm-jumpbox-linux/scripts/configure-vm-jumpbox-linux.sh` → one **documented** file-level `# shellcheck disable=SC2024` with justification (the redirect appends to the user-owned log and is intentionally non-elevated; rewriting as `sudo tee` would wrongly elevate the write and change `&>>` semantics).

**Docs**
- `CONTRIBUTING.md` — added the `ci-bash` row to the workflow table, the local `./scripts/Invoke-ShellCheck.sh` command, and a note on the SC2024 exclusion.

## Notes / decisions
- **Severity is set via the `--severity=warning` CLI flag**, not `.shellcheckrc`. ShellCheck ignores a `severity=` directive in the rc file (verified against 0.9.0 and 0.10.0), so the flag is the authoritative gate; `.shellcheckrc` holds shared config like `external-sources=false` and any future per-rule excludes.
- **No Dependabot change.** The pinned ShellCheck version (env var + curl download + SHA256) is not trackable by Dependabot's `github-actions` ecosystem, which only bumps `uses:` action refs. This matches the existing `GITLEAKS_VERSION` precedent in `ci-secrets.yml` (manual "Bump intentionally" model), and keeps the repo's deliberate no-Marketplace-action convention.

## Verification
- Whole tree lints clean: `./scripts/Invoke-ShellCheck.sh` → 0 warning/error findings.
- Workflow YAML validated; install + run steps simulated locally (tarball checksum OK).
- `markdownlint-cli2` passes on `CONTRIBUTING.md` (keeps `ci-docs` green).