### PR TITLE
chore(deps): bump azurerm to ~> 4.79.0 across all directories

### DIFF
--- a/extras/configurations/rg-devops-iac/modules/vm-jumpbox-linux/terraform.tf
+++ b/extras/configurations/rg-devops-iac/modules/vm-jumpbox-linux/terraform.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 4.78.0"
+      version = "~> 4.79.0"
     }
 
     cloudinit = {

--- a/extras/configurations/rg-devops-iac/terraform.tf
+++ b/extras/configurations/rg-devops-iac/terraform.tf
@@ -9,7 +9,7 @@ terraform {
 
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 4.78.0"
+      version = "~> 4.79.0"
     }
 
     cloudinit = {

--- a/extras/modules/avd/terraform.tf
+++ b/extras/modules/avd/terraform.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 4.78.0"
+      version = "~> 4.79.0"
     }
 
     time = {

--- a/extras/modules/petstore/terraform.tf
+++ b/extras/modules/petstore/terraform.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 4.78.0"
+      version = "~> 4.79.0"
     }
 
     null = {

--- a/extras/modules/vnet-onprem/terraform.tf
+++ b/extras/modules/vnet-onprem/terraform.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 4.78.0"
+      version = "~> 4.79.0"
     }
 
     time = {

--- a/modules/mssql/terraform.tf
+++ b/modules/mssql/terraform.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 4.78.0"
+      version = "~> 4.79.0"
     }
 
     random = {

--- a/modules/mysql/terraform.tf
+++ b/modules/mysql/terraform.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 4.78.0"
+      version = "~> 4.79.0"
     }
 
     random = {

--- a/modules/vm-jumpbox-linux/terraform.tf
+++ b/modules/vm-jumpbox-linux/terraform.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 4.78.0"
+      version = "~> 4.79.0"
     }
 
     cloudinit = {

--- a/modules/vm-mssql-win/terraform.tf
+++ b/modules/vm-mssql-win/terraform.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 4.78.0"
+      version = "~> 4.79.0"
     }
 
     random = {

--- a/modules/vnet-app/terraform.tf
+++ b/modules/vnet-app/terraform.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 4.78.0"
+      version = "~> 4.79.0"
     }
 
     random = {

--- a/modules/vnet-shared/terraform.tf
+++ b/modules/vnet-shared/terraform.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 4.78.0"
+      version = "~> 4.79.0"
     }
 
     random = {

--- a/modules/vwan/terraform.tf
+++ b/modules/vwan/terraform.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 4.78.0"
+      version = "~> 4.79.0"
     }
 
     tls = {

--- a/terraform.tf
+++ b/terraform.tf
@@ -14,7 +14,7 @@ terraform {
 
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 4.78.0"
+      version = "~> 4.79.0"
     }
 
     cloudinit = {


### PR DESCRIPTION
## Summary

Consolidates the Dependabot `terraform-all` group bump (azurerm `~> 4.78.0` → `~> 4.79.0`) into a **single cross-directory change** so the required `terraform validate (.)` check passes.

### Why
Dependabot split the bump into 14 per-directory PRs (#502–#515). In isolation each PR leaves the other directories at `4.78.0`, so root `terraform init` resolves a conflicting `~> 4.78.0, ~> 4.79.0` constraint and `terraform validate (.)` fails. The constraints can only resolve when every directory is bumped together.

### Changes
Bumps `hashicorp/azurerm` to `~> 4.79.0` in all 13 `terraform.tf` files still at `4.78.0` (root, all `modules/*`, and `extras/*`). `ai-foundry` was already bumped via #510; the retired `vm-devops-win` module (pinned 4.67.0) is intentionally left untouched.

### Validation
- `terraform validate (.)` — passes locally
- `terraform validate (extras/configurations/rg-devops-iac)` — passes locally

### Supersedes
Closes the split PRs: #502, #503, #504, #505, #506, #507, #508, #509, #511, #512, #513, #514, #515.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>