### PR TITLE
docs: correct vnext update method in CONTRIBUTING (PRs only)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,7 +44,7 @@ This repository uses a two-branch model to keep `main` stable and releasable at 
 
 | Branch | Purpose | Who can update it | How it is updated |
 | --- | --- | --- | --- |
-| `vnext` | Active development / integration branch. All day-to-day work lands here. | Any collaborator with write access | Pull requests (or direct pushes by maintainers) |
+| `vnext` | Active development / integration branch. All day-to-day work lands here. | Any collaborator with write access | Pull requests only (direct pushes are blocked) |
 | `main` | Stable, released code. | Repository owner **@doherty100** only | Pull request merging `vnext` → `main` |
 
 ### Workflow


### PR DESCRIPTION
## Summary

Fixes a stale claim in the *Branching and Merge Policy* table. The `vnext` row said it is updated via *"Pull requests (or direct pushes by maintainers)"*, but that is no longer true.

## Why
`vnext` now requires a pull request to update it:
- A `pull_request` ruleset rule **and** classic *"require a pull request before merging"* are active.
- `enforce_admins: true`, so even admins/owner cannot push directly.

Direct pushes to `vnext` are therefore blocked for everyone. Bypass-team members still merge via a PR (skipping the queue/approval) — they do not `git push` to `vnext`.

## Change
Table cell updated to **"Pull requests only (direct pushes are blocked)"**.

The rest of the merge documentation (Paths 1 & 2, merge strategy) was verified consistent with the live ruleset/branch-protection config and needed no changes.

## Validation
- `markdownlint-cli2` — passes locally (0 errors)

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>