### PR TITLE
ci(docs): exclude Entra admin center from lychee link check

### DIFF
--- a/lychee.toml
+++ b/lychee.toml
@@ -1,0 +1,12 @@
+# Configuration for the lychee link checker.
+# Auto-detected by lychee (and lycheeverse/lychee-action) in the repo root, so
+# it applies to both the PR-time offline check (ci-docs.yml) and the scheduled
+# external link check (ci-docs-external-links.yml).
+
+# Hosts that reject automated requests (bot protection) and therefore produce
+# false-positive failures even though the links are valid in a browser.
+exclude = [
+  # The Microsoft Entra admin center returns 403 Forbidden to non-browser
+  # user agents (see issue #516). The URL is valid for human visitors.
+  "^https://entra\\.microsoft\\.com",
+]


### PR DESCRIPTION
## Summary

Fixes #516.

The scheduled external link check (`ci-docs-external-links.yml`) reports a false-positive `403 Forbidden` for <https://entra.microsoft.com>, which rejects non-browser user agents even though the link is valid for human visitors. This keeps re-opening/updating the tracking issue.

## Change

Add a `lychee.toml` config (auto-detected by `lycheeverse/lychee-action` in the repo root, so it applies to both the PR-time offline check and the scheduled external check) that excludes the Entra admin center host.

## Verification

Ran lychee locally against `README.md`:

- **Without exclusion:** `🚫 1 Error` — `[403] https://entra.microsoft.com/`
- **With `lychee.toml`:** `🚫 0 Errors`, `[EXCLUDED] https://entra.microsoft.com/`