### PR TITLE
chore: bump Terraform CLI to 1.15.7

### DIFF
--- a/.github/workflows/ci-terraform.yml
+++ b/.github/workflows/ci-terraform.yml
@@ -25,8 +25,8 @@ jobs:
 
       - uses: hashicorp/setup-terraform@v3
         with:
-          # Matches required_version (~> 1.15.6) in terraform.tf.
-          terraform_version: 1.15.6
+          # Matches required_version (~> 1.15.7) in terraform.tf.
+          terraform_version: 1.15.7
           terraform_wrapper: false
 
       - name: Check formatting
@@ -77,8 +77,8 @@ jobs:
 
       - uses: hashicorp/setup-terraform@v3
         with:
-          # Matches required_version (~> 1.15.6) in terraform.tf.
-          terraform_version: 1.15.6
+          # Matches required_version (~> 1.15.7) in terraform.tf.
+          terraform_version: 1.15.7
           terraform_wrapper: false
 
       # -backend=false downloads providers/initializes modules without

--- a/extras/configurations/rg-devops-iac/modules/vm-jumpbox-linux/terraform.tf
+++ b/extras/configurations/rg-devops-iac/modules/vm-jumpbox-linux/terraform.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 1.15.6"
+  required_version = "~> 1.15.7"
 
   required_providers {
     azurerm = {

--- a/extras/configurations/rg-devops-iac/terraform.tf
+++ b/extras/configurations/rg-devops-iac/terraform.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 1.15.6"
+  required_version = "~> 1.15.7"
 
   required_providers {
     azapi = {

--- a/extras/modules/ai-foundry/terraform.tf
+++ b/extras/modules/ai-foundry/terraform.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 1.15.6"
+  required_version = "~> 1.15.7"
 
   required_providers {
     azapi = {

--- a/extras/modules/avd/terraform.tf
+++ b/extras/modules/avd/terraform.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 1.15.6"
+  required_version = "~> 1.15.7"
 
   required_providers {
     azurerm = {

--- a/extras/modules/petstore/terraform.tf
+++ b/extras/modules/petstore/terraform.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 1.15.6"
+  required_version = "~> 1.15.7"
 
   required_providers {
     azurerm = {

--- a/extras/modules/retired/vm-devops-win/terraform.tf
+++ b/extras/modules/retired/vm-devops-win/terraform.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 1.15.6"
+  required_version = "~> 1.15.7"
 
   required_providers {
     azurerm = {

--- a/extras/modules/vnet-onprem/terraform.tf
+++ b/extras/modules/vnet-onprem/terraform.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 1.15.6"
+  required_version = "~> 1.15.7"
 
   required_providers {
     azurerm = {

--- a/modules/mssql/terraform.tf
+++ b/modules/mssql/terraform.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 1.15.6"
+  required_version = "~> 1.15.7"
 
   required_providers {
     azurerm = {

--- a/modules/mysql/terraform.tf
+++ b/modules/mysql/terraform.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 1.15.6"
+  required_version = "~> 1.15.7"
 
   required_providers {
     azurerm = {

--- a/modules/vm-jumpbox-linux/terraform.tf
+++ b/modules/vm-jumpbox-linux/terraform.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 1.15.6"
+  required_version = "~> 1.15.7"
 
   required_providers {
     azurerm = {

--- a/modules/vm-mssql-win/terraform.tf
+++ b/modules/vm-mssql-win/terraform.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 1.15.6"
+  required_version = "~> 1.15.7"
 
   required_providers {
     azurerm = {

--- a/modules/vnet-app/terraform.tf
+++ b/modules/vnet-app/terraform.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 1.15.6"
+  required_version = "~> 1.15.7"
 
   required_providers {
     azurerm = {

--- a/modules/vnet-shared/terraform.tf
+++ b/modules/vnet-shared/terraform.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 1.15.6"
+  required_version = "~> 1.15.7"
 
   required_providers {
     azurerm = {

--- a/modules/vwan/terraform.tf
+++ b/modules/vwan/terraform.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 1.15.6"
+  required_version = "~> 1.15.7"
 
   required_providers {
     azurerm = {

--- a/terraform.tf
+++ b/terraform.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 1.15.6"
+  required_version = "~> 1.15.7"
 
   required_providers {
     azuread = {


### PR DESCRIPTION
## Summary

Bumps the pinned Terraform CLI version from `1.15.6` to `1.15.7` across the repository.

## Changes

- Updated `required_version = "~> 1.15.7"` in the root `terraform.tf` and in every module's `terraform.tf` (base `modules/*` and `extras/*`, including the retired `vm-devops-win` module and the standalone `rg-devops-iac` configuration).
- Updated the `hashicorp/setup-terraform` `terraform_version` (and matching comment) in `.github/workflows/ci-terraform.yml` for both CI jobs so CI stays aligned with the pinned version.

16 files changed, version-pin only — no functional/resource changes.