### PR TITLE
ci: gate lint/validate workflows by changed paths

### DIFF
--- a/.github/workflows/ci-actions.yml
+++ b/.github/workflows/ci-actions.yml
@@ -13,15 +13,42 @@ on:
 
 permissions:
   contents: read
+  # Required by the `changes` job's paths-filter to read changed files via the
+  # PR API on pull_request events.
+  pull-requests: read
 
 concurrency:
   group: ci-actions-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
+  # Detect whether this push/PR touches workflow files. The real job is gated on
+  # this so it only runs when workflows change. A skipped required job satisfies
+  # branch protection, whereas a path-filtered workflow that never runs would
+  # leave a required check pending forever. Do NOT convert this to a trigger-level
+  # `paths:` filter while actionlint is a required check on vnext.
+  changes:
+    name: detect changes
+    runs-on: ubuntu-latest
+    outputs:
+      actions: ${{ steps.filter.outputs.actions }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            actions:
+              - '.github/workflows/**'
+
   actionlint:
     name: actionlint
     runs-on: ubuntu-latest
+    needs: changes
+    if: ${{ needs.changes.outputs.actions == 'true' }}
     env:
       # Pinned for deterministic, reproducible runs. Bump intentionally.
       ACTIONLINT_VERSION: 1.7.12

--- a/.github/workflows/ci-bash.yml
+++ b/.github/workflows/ci-bash.yml
@@ -16,15 +16,44 @@ on:
 
 permissions:
   contents: read
+  # Required by the `changes` job's paths-filter to read changed files via the
+  # PR API on pull_request events.
+  pull-requests: read
 
 concurrency:
   group: ci-bash-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
+  # Detect whether this push/PR touches shell scripts. The real job is gated on
+  # this so it only runs when relevant files change. A skipped required job
+  # satisfies branch protection, whereas a path-filtered workflow that never runs
+  # would leave a required check pending forever. Do NOT convert this to a
+  # trigger-level `paths:` filter while ShellCheck is a required check on vnext.
+  changes:
+    name: detect changes
+    runs-on: ubuntu-latest
+    outputs:
+      bash: ${{ steps.filter.outputs.bash }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            bash:
+              - '**/*.sh'
+              - '.shellcheckrc'
+              - '.github/workflows/ci-bash.yml'
+
   shellcheck:
     name: ShellCheck
     runs-on: ubuntu-latest
+    needs: changes
+    if: ${{ needs.changes.outputs.bash == 'true' }}
     env:
       # Pinned for deterministic, reproducible scans. Bump intentionally.
       SHELLCHECK_VERSION: 0.10.0

--- a/.github/workflows/ci-docs.yml
+++ b/.github/workflows/ci-docs.yml
@@ -11,15 +11,46 @@ on:
 
 permissions:
   contents: read
+  # Required by the `changes` job's paths-filter to read changed files via the
+  # PR API on pull_request events.
+  pull-requests: read
 
 concurrency:
   group: ci-docs-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
+  # Detect whether this push/PR touches documentation. The real jobs below are
+  # gated on this so they only run when relevant files change. They `needs` this
+  # job and are *skipped* (not absent) when nothing matches: a skipped required
+  # job satisfies branch protection, whereas a path-filtered workflow that never
+  # runs would leave a required check pending forever. Do NOT convert this to a
+  # trigger-level `paths:` filter while these checks are required on vnext.
+  changes:
+    name: detect changes
+    runs-on: ubuntu-latest
+    outputs:
+      docs: ${{ steps.filter.outputs.docs }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            docs:
+              - '**/*.md'
+              - '.markdownlint.jsonc'
+              - '.markdownlint-cli2.jsonc'
+              - '.github/workflows/ci-docs.yml'
+
   markdownlint:
     name: markdownlint
     runs-on: ubuntu-latest
+    needs: changes
+    if: ${{ needs.changes.outputs.docs == 'true' }}
     steps:
       - uses: actions/checkout@v4
 
@@ -36,6 +67,8 @@ jobs:
   lychee:
     name: lychee (internal links)
     runs-on: ubuntu-latest
+    needs: changes
+    if: ${{ needs.changes.outputs.docs == 'true' }}
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/ci-powershell.yml
+++ b/.github/workflows/ci-powershell.yml
@@ -11,15 +11,45 @@ on:
 
 permissions:
   contents: read
+  # Required by the `changes` job's paths-filter to read changed files via the
+  # PR API on pull_request events.
+  pull-requests: read
 
 concurrency:
   group: ci-powershell-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
+  # Detect whether this push/PR touches PowerShell. The real job is gated on this
+  # so it only runs when relevant files change. A skipped required job satisfies
+  # branch protection, whereas a path-filtered workflow that never runs would
+  # leave a required check pending forever. Do NOT convert this to a trigger-level
+  # `paths:` filter while PSScriptAnalyzer is a required check on vnext.
+  changes:
+    name: detect changes
+    runs-on: ubuntu-latest
+    outputs:
+      powershell: ${{ steps.filter.outputs.powershell }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            powershell:
+              - '**/*.ps1'
+              - '**/*.psm1'
+              - '**/*.psd1'
+              - '.github/workflows/ci-powershell.yml'
+
   psscriptanalyzer:
     name: PSScriptAnalyzer
     runs-on: ubuntu-latest
+    needs: changes
+    if: ${{ needs.changes.outputs.powershell == 'true' }}
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/ci-terraform.yml
+++ b/.github/workflows/ci-terraform.yml
@@ -11,15 +11,48 @@ on:
 
 permissions:
   contents: read
+  # Required by the `changes` job's paths-filter to read changed files via the
+  # PR API on pull_request events.
+  pull-requests: read
 
 concurrency:
   group: ci-terraform-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
+  # Detect whether this push/PR touches Terraform. The real jobs below are gated
+  # on this so they only run when relevant files change. They are *skipped* (not
+  # absent) when nothing matches: a skipped required job satisfies branch
+  # protection, whereas a path-filtered workflow that never runs would leave a
+  # required check pending forever. Do NOT convert this to a trigger-level
+  # `paths:` filter while these checks are required on vnext.
+  # Note: .terraform.lock.hcl is intentionally omitted — it is gitignored in this
+  # repo and never committed.
+  changes:
+    name: detect changes
+    runs-on: ubuntu-latest
+    outputs:
+      terraform: ${{ steps.filter.outputs.terraform }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            terraform:
+              - '**/*.tf'
+              - '**/*.tf.json'
+              - '**/.tflint.hcl'
+              - '.github/workflows/ci-terraform.yml'
+
   fmt:
     name: terraform fmt
     runs-on: ubuntu-latest
+    needs: changes
+    if: ${{ needs.changes.outputs.terraform == 'true' }}
     steps:
       - uses: actions/checkout@v4
 
@@ -35,6 +68,8 @@ jobs:
   tflint:
     name: tflint
     runs-on: ubuntu-latest
+    needs: changes
+    if: ${{ needs.changes.outputs.terraform == 'true' }}
     env:
       # Used by `tflint --init` to download the azurerm ruleset plugin from
       # GitHub releases without hitting unauthenticated rate limits.
@@ -63,6 +98,8 @@ jobs:
   validate:
     name: terraform validate
     runs-on: ubuntu-latest
+    needs: changes
+    if: ${{ needs.changes.outputs.terraform == 'true' }}
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Summary

Stop running every CI check on every PR/push. Each check now runs **only when files it cares about change** — e.g. markdownlint no longer runs on a Terraform-only PR, PSScriptAnalyzer no longer runs when no PowerShell changed.

## Why not a simple `paths:` filter?

All 10 CI contexts are **required status checks** on `vnext` (`strict: true`). A trigger-level `paths:` filter would make a non-matching workflow *never run*, leaving its required check **pending forever** and blocking the PR.

Instead, each workflow keeps its existing triggers and adds a lightweight `changes` job (`dorny/paths-filter@v3`) that detects relevant changes; the real jobs are gated with `needs: changes` + `if:`. A **skipped** required job *satisfies* branch protection, so PRs stay unblocked while skipping irrelevant work. No branch-protection changes are required.

## Per-workflow filters

| Workflow | Runs when changed |
|---|---|
| `ci-terraform` (fmt, tflint, validate) | `**/*.tf`, `**/*.tf.json`, `**/.tflint.hcl`, own workflow |
| `ci-docs` (markdownlint, lychee) | `**/*.md`, `.markdownlint*.jsonc`, own workflow |
| `ci-powershell` (PSScriptAnalyzer) | `**/*.ps1/.psm1/.psd1`, own workflow |
| `ci-bash` (ShellCheck) | `**/*.sh`, `.shellcheckrc`, own workflow |
| `ci-actions` (actionlint) | `.github/workflows/**` |
| `ci-secrets` (gitleaks) | **unchanged — always runs** (secrets can land in any file type) |

## Notes

- **Gitignored artifacts are intentionally excluded** from filters — notably `.terraform.lock.hcl`, which is gitignored and never committed.
- The matrix `validate` job's per-matrix contexts (`terraform validate (.)`, `terraform validate (extras/...)`) still report as *skipped* when gated off, satisfying their required checks.
- Each workflow also re-validates itself by including its own path in the filter.
- Validated locally with `actionlint` (clean) and YAML parse.

Each `changes` job adds one tiny extra runner per workflow, far cheaper than running the full linter/validation suite unconditionally.