### PR TITLE
Make Linux AMA unit test resilient to extension cold-start (#524)

### DIFF
--- a/modules/vm-jumpbox-linux/scripts/test-vm-jumpbox-linux.sh
+++ b/modules/vm-jumpbox-linux/scripts/test-vm-jumpbox-linux.sh
@@ -225,16 +225,45 @@ fi
 # AMA - Azure Monitor Agent systemd service is active.
 # Unlike the Windows agent, AMA on Linux registers a systemd unit (azuremonitoragent.service)
 # and the canonical health check is systemctl is-active.
+#
+# After a VM stop/deallocate+start (e.g. Invoke-UnitTests.ps1 cycling a VM, or a cost-
+# optimization auto-shutdown policy) the extension handler restarts the agent asynchronously
+# and does not block VM startup, so the service can take up to ~2 min to become 'active'.
+# Poll with a bounded wait so the test is resilient to extension cold-start, and on timeout
+# emit diagnostics (service state, VM uptime, latest extension handler status) that
+# distinguish a slow start from a real extension failure. Mirrors the Windows AMA fix (#424).
+ama_max_wait_sec=120
+ama_sleep_sec=5
+ama_waited=0
 ama_status=$(systemctl is-active azuremonitoragent 2>/dev/null)
+while [ "$ama_status" != "active" ] && [ "$ama_waited" -lt "$ama_max_wait_sec" ]; do
+    sleep "$ama_sleep_sec"
+    ama_waited=$((ama_waited + ama_sleep_sec))
+    ama_status=$(systemctl is-active azuremonitoragent 2>/dev/null)
+done
+
 if [ "$ama_status" = "active" ]; then
     ama_version=$(dpkg-query -W -f='${Version}' azuremonitoragent 2>/dev/null)
     if [ -z "$ama_version" ]; then
         ama_version='unknown'
     fi
-    write_test_result 'PASS' "AMA: azuremonitoragent.service is active (version $ama_version)"
+    write_test_result 'PASS' "AMA: azuremonitoragent.service is active (version $ama_version, waited ${ama_waited}s)"
     passed=$((passed + 1))
 else
-    write_test_result 'FAIL' "AMA: azuremonitoragent.service is '$ama_status' (expected 'active')"
+    # Distinguish a slow extension cold-start from a real extension failure: report VM uptime
+    # and the latest AMA extension handler status written by the Azure guest agent (waagent).
+    ama_uptime=$(awk '{print int($1)}' /proc/uptime 2>/dev/null)
+    [ -z "$ama_uptime" ] && ama_uptime='unknown'
+    ama_ext_status='no status file'
+    ama_ext_dir=$(find /var/lib/waagent -maxdepth 1 -type d -name 'Microsoft.Azure.Monitor.AzureMonitorLinuxAgent-*' 2>/dev/null | sort -V | tail -1)
+    if [ -n "$ama_ext_dir" ]; then
+        ama_status_file=$(find "$ama_ext_dir/status" -maxdepth 1 -name '*.status' -printf '%T@ %p\n' 2>/dev/null | sort -n | tail -1 | cut -d' ' -f2-)
+        if [ -n "$ama_status_file" ]; then
+            ama_ext_status=$(python3 -c "import json,sys; s=json.load(open(sys.argv[1]))[0]['status']; print('status=%s message=%s' % (s.get('status'), s.get('formattedMessage',{}).get('message','')))" "$ama_status_file" 2>/dev/null)
+            [ -z "$ama_ext_status" ] && ama_ext_status="see $ama_status_file"
+        fi
+    fi
+    write_test_result 'FAIL' "AMA: azuremonitoragent.service is '$ama_status' after ${ama_waited}s (expected 'active'; vm_uptime=${ama_uptime}s, ext: $ama_ext_status)"
     failed=$((failed + 1))
 fi
 


### PR DESCRIPTION
## Summary

Makes the Linux jumpbox AMA unit test resilient to Azure Monitor Agent **extension cold-start**, closing the gap that #524 surfaced. This is the Linux counterpart of #424 (which fixed the same false-positive class for the three Windows test scripts but was never extended to the Linux test).

Closes #524.

## Problem

`modules/vm-jumpbox-linux/scripts/test-vm-jumpbox-linux.sh` checked AMA health with a **single-shot** `systemctl is-active azuremonitoragent` and FAILed immediately on anything other than `active`. After a VM stop/deallocate+start — which `Invoke-UnitTests.ps1` does to dependency VMs, and which a cost-optimization auto-shutdown policy can do at any time — the extension handler restarts the agent asynchronously and does not block VM startup, so the service can take up to ~2 min to become `active`. The single-shot check therefore produced false-positive FAILs during cold-start.

(Note: the original #524 `terraform apply` extension-install failure itself was transient and did not reproduce. This PR addresses the genuine, standing test-resilience gap that the repro investigation uncovered.)

## Change

`modules/vm-jumpbox-linux/scripts/test-vm-jumpbox-linux.sh` (+31/−2):

- Wrap the AMA check in a **120 s bounded poll (5 s sleep)**, mirroring #424.
- On PASS, append the elapsed wait time (e.g. `waited 0s`).
- On final timeout, emit **VM uptime** and the **latest AMA extension handler status** (parsed from the waagent `.status` file) so a slow cold-start is distinguishable from a real extension failure (e.g. the `Unit azuremonitoragent.service could not be found` error from #524).
- Return semantics preserved (exactly one PASS or FAIL) so summary counts stay stable.

## Testing

- `bash -n` syntax check: OK
- ShellCheck: clean at all severities (gate is `--severity=warning`)
- End-to-end against a fresh `jumplinux1` (`pwsh -File ./scripts/Invoke-UnitTests.ps1 -Module vm_jumpbox_linux -Integration`):

  ```
  [PASS] AMA: azuremonitoragent.service is active (version 1.42.0-1441, waited 0s)
  [MODULE:vm-jumpbox-linux] [SUMMARY] Passed: 13 Failed: 0 Total: 13
  [integration] SSH: jumpwin1 -> jumplinux1: Passed=1 Failed=0
  Overall: Passed=14 Failed=0 Total=14
  RESULT: PASS
  ```

  The `waited 0s` suffix confirms the new bounded-poll path executes (fast-passes when the agent is already active).
