### PR TITLE
ci: always run terraform validate matrix so required contexts report

### DIFF
--- a/.github/workflows/ci-terraform.yml
+++ b/.github/workflows/ci-terraform.yml
@@ -21,11 +21,14 @@ concurrency:
 
 jobs:
   # Detect whether this push/PR touches Terraform. The real jobs below are gated
-  # on this so they only run when relevant files change. They are *skipped* (not
-  # absent) when nothing matches: a skipped required job satisfies branch
+  # on this so they only do work when relevant files change. Single-job checks
+  # (fmt, tflint) are *skipped* (not absent) when nothing matches: a skipped
+  # required job whose check name matches the required context satisfies branch
   # protection, whereas a path-filtered workflow that never runs would leave a
   # required check pending forever. Do NOT convert this to a trigger-level
   # `paths:` filter while these checks are required on vnext.
+  # NOTE: the `validate` job is a *matrix* job and is handled differently — see
+  # the comment on that job for why it must always run rather than be skipped.
   # Note: .terraform.lock.hcl is intentionally omitted — it is gitignored in this
   # repo and never committed.
   changes:
@@ -99,7 +102,17 @@ jobs:
     name: terraform validate
     runs-on: ubuntu-latest
     needs: changes
-    if: ${{ needs.changes.outputs.terraform == 'true' }}
+    # Unlike the single-job checks above, this is a *matrix* job, so its
+    # branch-protection contexts are the matrix-expanded names
+    # `terraform validate (.)` and
+    # `terraform validate (extras/configurations/rg-devops-iac)`.
+    # A job-level `if` skip would collapse the matrix into a single skipped
+    # `terraform validate` check, so those two required contexts would NEVER be
+    # reported and a non-Terraform PR would wait on them forever ("Expected —
+    # Waiting for status to be reported"). Therefore this job must ALWAYS run so
+    # the matrix expands and both contexts report; the per-step `if` below
+    # no-ops the actual work when Terraform is unchanged. Do NOT reintroduce a
+    # job-level `if` here.
     strategy:
       fail-fast: false
       matrix:
@@ -111,8 +124,10 @@ jobs:
           - extras/configurations/rg-devops-iac
     steps:
       - uses: actions/checkout@v4
+        if: ${{ needs.changes.outputs.terraform == 'true' }}
 
       - uses: hashicorp/setup-terraform@v3
+        if: ${{ needs.changes.outputs.terraform == 'true' }}
         with:
           # Matches required_version (~> 1.15.7) in terraform.tf.
           terraform_version: 1.15.7
@@ -121,9 +136,11 @@ jobs:
       # -backend=false downloads providers/initializes modules without
       # configuring remote state, so validation needs no Azure credentials.
       - name: terraform init (no backend)
+        if: ${{ needs.changes.outputs.terraform == 'true' }}
         run: terraform init -backend=false -input=false
         working-directory: ${{ matrix.dir }}
 
       - name: terraform validate
+        if: ${{ needs.changes.outputs.terraform == 'true' }}
         run: terraform validate -no-color
         working-directory: ${{ matrix.dir }}


### PR DESCRIPTION
## Summary

Fixes a branch-protection deadlock: **any PR that doesn't touch Terraform currently cannot merge** because two required status checks are never reported. This is what is blocking #525.

## Root cause

`vnext` branch protection requires these contexts:

- `terraform validate (.)`
- `terraform validate (extras/configurations/rg-devops-iac)`

These names come from the **matrix** expansion of the `validate` job in `.github/workflows/ci-terraform.yml` (`dir: [".", "extras/configurations/rg-devops-iac"]` → `terraform validate (<dir>)`).

When the lint/validate workflows were path-gated (#523), `validate` got a job-level `if: needs.changes.outputs.terraform == 'true'`. On a non-Terraform PR that condition is false, so the **entire job is skipped before the matrix expands**. GitHub then reports a single collapsed `terraform validate` check (skipped) and **never emits the two matrix-suffixed contexts** that branch protection requires. Result: the PR sits forever on **"Expected — Waiting for status to be reported" / "Some checks haven't completed yet"** and cannot merge.

The single-job checks (`fmt`, `tflint`, plus `actionlint`, `markdownlint`, `PSScriptAnalyzer`, `lychee`) are unaffected: a skipped check whose name exactly matches its required context already satisfies branch protection. Only the **matrix** job has the name-mismatch problem.

## Change

`.github/workflows/ci-terraform.yml`:

- Remove the job-level `if` from `validate` so the job **always runs** and the matrix expands → both `terraform validate (.)` and `terraform validate (extras/configurations/rg-devops-iac)` contexts are always reported.
- Move the path gate to each step (`if: needs.changes.outputs.terraform == 'true'`) so the actual init/validate work **no-ops when Terraform is unchanged** — same cost savings as #523, without dropping the required contexts.
- Update the explanatory comments to document why the matrix job must always run (and must not get a job-level `if` reintroduced).

No change to behavior when Terraform **is** modified: the steps run exactly as before.

## Testing

- `actionlint` 1.7.12 (the pinned CI version): **clean**, no findings across all workflows.
- YAML parses successfully.
- After merge, this PR's own run will exercise the no-op path (it changes only a workflow file, not `*.tf`), so the two `terraform validate (...)` contexts should report green-skipped here.

## Related

Unblocks #525 (the Linux AMA test fix), which is currently stuck on exactly these two checks.

