### PR TITLE
ci: trigger required checks on merge_group to unblock vnext merge queue

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -237,7 +237,7 @@ Every module has a `README.md` with the same sections: Architecture (drawio SVG 
 
 - Day-to-day work happens on `vnext`; PRs target `vnext`.
 - A CLA bot runs on PRs (Microsoft Open Source CLA).
-- `.vscode/tasks.json` provides a one-shot task to squash-merge all open PRs into `vnext` (`gh pr list ... | xargs gh pr merge --squash`).
+- `.vscode/tasks.json` provides a one-shot task to squash-merge **only Dependabot-generated** open PRs into `vnext` — it filters on `--author "app/dependabot"` (`gh pr list --author "app/dependabot" ... | xargs gh pr merge --squash --admin`). It is **not** a general "merge all open PRs" task; human/contributor PRs are unaffected and must be merged individually per the merge strategy below.
 - **Merge strategy:** squash-merge topic/contributor PRs → `vnext`; use a **regular merge commit (no squash)** for the `vnext` → `main` release PR so individual commits and branch lineage are preserved on `main`. See CONTRIBUTING.md "Merge strategy".
 
 ## Standalone configurations under `extras/configurations/`

--- a/.github/workflows/ci-actions.yml
+++ b/.github/workflows/ci-actions.yml
@@ -1,7 +1,9 @@
 # CI: GitHub Actions workflow linting (actionlint).
 # Lints the workflow files themselves for syntax errors, bad expressions,
 # deprecated runners, and shell-script issues in `run:` steps.
-# Runs on every pull request targeting vnext and on pushes to vnext.
+# Runs on every pull request targeting vnext, on pushes to vnext, and on
+# merge_group events so the required "actionlint" context reports on the merge
+# queue's temporary branch (the vnext-merge-queue ruleset requires it).
 name: ci-actions
 
 on:
@@ -9,6 +11,8 @@ on:
     branches: [vnext]
   push:
     branches: [vnext]
+  merge_group:
+    types: [checks_requested]
   workflow_dispatch:
 
 permissions:
@@ -37,8 +41,12 @@ jobs:
         with:
           fetch-depth: 0
 
+      # On merge_group events there is no PR to diff against; the queue branch
+      # already contains the merged result, so skip the filter and let the real
+      # check run below (see the job `if`). Runs normally on pull_request/push.
       - uses: dorny/paths-filter@v3
         id: filter
+        if: ${{ github.event_name != 'merge_group' }}
         with:
           filters: |
             actions:
@@ -48,7 +56,9 @@ jobs:
     name: actionlint
     runs-on: ubuntu-latest
     needs: changes
-    if: ${{ needs.changes.outputs.actions == 'true' }}
+    # Always run in the merge queue (validate the merged result); on PR/push,
+    # run only when workflow files changed.
+    if: ${{ needs.changes.outputs.actions == 'true' || github.event_name == 'merge_group' }}
     env:
       # Pinned for deterministic, reproducible runs. Bump intentionally.
       ACTIONLINT_VERSION: 1.7.12

--- a/.github/workflows/ci-bash.yml
+++ b/.github/workflows/ci-bash.yml
@@ -4,7 +4,9 @@
 # (per-rule excludes, external-sources) lives in the repo-root .shellcheckrc; the
 # warning+error gate is applied via the --severity flag below. Developers can run
 # the identical check locally with scripts/Invoke-ShellCheck.sh.
-# Runs on every pull request targeting vnext and on pushes to vnext.
+# Runs on every pull request targeting vnext, on pushes to vnext, and on
+# merge_group events so the required "ShellCheck" context reports on the merge
+# queue's temporary branch (the vnext-merge-queue ruleset requires it).
 name: ci-bash
 
 on:
@@ -12,6 +14,8 @@ on:
     branches: [vnext]
   push:
     branches: [vnext]
+  merge_group:
+    types: [checks_requested]
   workflow_dispatch:
 
 permissions:
@@ -40,8 +44,12 @@ jobs:
         with:
           fetch-depth: 0
 
+      # On merge_group events there is no PR to diff against; the queue branch
+      # already contains the merged result, so skip the filter and let the real
+      # check run below (see the job `if`). Runs normally on pull_request/push.
       - uses: dorny/paths-filter@v3
         id: filter
+        if: ${{ github.event_name != 'merge_group' }}
         with:
           filters: |
             bash:
@@ -53,7 +61,9 @@ jobs:
     name: ShellCheck
     runs-on: ubuntu-latest
     needs: changes
-    if: ${{ needs.changes.outputs.bash == 'true' }}
+    # Always run in the merge queue (validate the merged result); on PR/push,
+    # run only when shell scripts changed.
+    if: ${{ needs.changes.outputs.bash == 'true' || github.event_name == 'merge_group' }}
     env:
       # Pinned for deterministic, reproducible scans. Bump intentionally.
       SHELLCHECK_VERSION: 0.10.0

--- a/.github/workflows/ci-docs.yml
+++ b/.github/workflows/ci-docs.yml
@@ -1,5 +1,8 @@
 # CI: documentation checks (markdownlint + lychee link checker).
-# Runs on every pull request targeting vnext and on pushes to vnext.
+# Runs on every pull request targeting vnext, on pushes to vnext, and on
+# merge_group events so the required "markdownlint" and "lychee (internal links)"
+# contexts report on the merge queue's temporary branch (the vnext-merge-queue
+# ruleset requires them).
 name: ci-docs
 
 on:
@@ -7,6 +10,8 @@ on:
     branches: [vnext]
   push:
     branches: [vnext]
+  merge_group:
+    types: [checks_requested]
   workflow_dispatch:
 
 permissions:
@@ -36,8 +41,12 @@ jobs:
         with:
           fetch-depth: 0
 
+      # On merge_group events there is no PR to diff against; the queue branch
+      # already contains the merged result, so skip the filter and let the real
+      # checks run below (see the job `if`s). Runs normally on pull_request/push.
       - uses: dorny/paths-filter@v3
         id: filter
+        if: ${{ github.event_name != 'merge_group' }}
         with:
           filters: |
             docs:
@@ -50,7 +59,9 @@ jobs:
     name: markdownlint
     runs-on: ubuntu-latest
     needs: changes
-    if: ${{ needs.changes.outputs.docs == 'true' }}
+    # Always run in the merge queue (validate the merged result); on PR/push,
+    # run only when docs changed.
+    if: ${{ needs.changes.outputs.docs == 'true' || github.event_name == 'merge_group' }}
     steps:
       - uses: actions/checkout@v4
 
@@ -68,7 +79,9 @@ jobs:
     name: lychee (internal links)
     runs-on: ubuntu-latest
     needs: changes
-    if: ${{ needs.changes.outputs.docs == 'true' }}
+    # Always run in the merge queue (validate the merged result); on PR/push,
+    # run only when docs changed.
+    if: ${{ needs.changes.outputs.docs == 'true' || github.event_name == 'merge_group' }}
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/ci-powershell.yml
+++ b/.github/workflows/ci-powershell.yml
@@ -1,5 +1,7 @@
 # CI: PowerShell static analysis (PSScriptAnalyzer).
-# Runs on every pull request targeting vnext and on pushes to vnext.
+# Runs on every pull request targeting vnext, on pushes to vnext, and on
+# merge_group events so the required "PSScriptAnalyzer" context reports on the
+# merge queue's temporary branch (the vnext-merge-queue ruleset requires it).
 name: ci-powershell
 
 on:
@@ -7,6 +9,8 @@ on:
     branches: [vnext]
   push:
     branches: [vnext]
+  merge_group:
+    types: [checks_requested]
   workflow_dispatch:
 
 permissions:
@@ -35,8 +39,12 @@ jobs:
         with:
           fetch-depth: 0
 
+      # On merge_group events there is no PR to diff against; the queue branch
+      # already contains the merged result, so skip the filter and let the real
+      # check run below (see the job `if`). Runs normally on pull_request/push.
       - uses: dorny/paths-filter@v3
         id: filter
+        if: ${{ github.event_name != 'merge_group' }}
         with:
           filters: |
             powershell:
@@ -49,7 +57,9 @@ jobs:
     name: PSScriptAnalyzer
     runs-on: ubuntu-latest
     needs: changes
-    if: ${{ needs.changes.outputs.powershell == 'true' }}
+    # Always run in the merge queue (validate the merged result); on PR/push,
+    # run only when PowerShell files changed.
+    if: ${{ needs.changes.outputs.powershell == 'true' || github.event_name == 'merge_group' }}
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/ci-secrets.yml
+++ b/.github/workflows/ci-secrets.yml
@@ -1,7 +1,9 @@
 # CI: secret scanning (gitleaks).
 # Catches credentials accidentally committed to the tree, complementing the
 # .gitignore rules for *.tfvars, *.pem, *.pfx and *.tfstate*.
-# Runs on every pull request targeting vnext and on pushes to vnext.
+# Runs on every pull request targeting vnext, on pushes to vnext, and on
+# merge_group events so the required "gitleaks" context reports on the merge
+# queue's temporary branch (the vnext-merge-queue ruleset requires it).
 name: ci-secrets
 
 on:
@@ -9,6 +11,8 @@ on:
     branches: [vnext]
   push:
     branches: [vnext]
+  merge_group:
+    types: [checks_requested]
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/ci-terraform.yml
+++ b/.github/workflows/ci-terraform.yml
@@ -1,5 +1,8 @@
 # CI: Terraform checks (formatting + tflint static analysis).
-# Runs on every pull request targeting vnext and on pushes to vnext.
+# Runs on every pull request targeting vnext, on pushes to vnext, and on
+# merge_group events so the required "terraform fmt", "tflint" and
+# "terraform validate (...)" contexts report on the merge queue's temporary
+# branch (the vnext-merge-queue ruleset requires them).
 name: ci-terraform
 
 on:
@@ -7,6 +10,8 @@ on:
     branches: [vnext]
   push:
     branches: [vnext]
+  merge_group:
+    types: [checks_requested]
   workflow_dispatch:
 
 permissions:
@@ -41,8 +46,13 @@ jobs:
         with:
           fetch-depth: 0
 
+      # On merge_group events there is no PR to diff against; the queue branch
+      # already contains the merged result, so skip the filter and let the real
+      # checks run (the `fmt`/`tflint` job `if`s and the `validate` per-step
+      # `if`s all also fire on merge_group). Runs normally on pull_request/push.
       - uses: dorny/paths-filter@v3
         id: filter
+        if: ${{ github.event_name != 'merge_group' }}
         with:
           filters: |
             terraform:
@@ -55,7 +65,7 @@ jobs:
     name: terraform fmt
     runs-on: ubuntu-latest
     needs: changes
-    if: ${{ needs.changes.outputs.terraform == 'true' }}
+    if: ${{ needs.changes.outputs.terraform == 'true' || github.event_name == 'merge_group' }}
     steps:
       - uses: actions/checkout@v4
 
@@ -72,7 +82,7 @@ jobs:
     name: tflint
     runs-on: ubuntu-latest
     needs: changes
-    if: ${{ needs.changes.outputs.terraform == 'true' }}
+    if: ${{ needs.changes.outputs.terraform == 'true' || github.event_name == 'merge_group' }}
     env:
       # Used by `tflint --init` to download the azurerm ruleset plugin from
       # GitHub releases without hitting unauthenticated rate limits.
@@ -113,6 +123,8 @@ jobs:
     # the matrix expands and both contexts report; the per-step `if` below
     # no-ops the actual work when Terraform is unchanged. Do NOT reintroduce a
     # job-level `if` here.
+    # On merge_group events the per-step `if`s also fire (the queue branch is the
+    # merged result), so validation actually runs there rather than no-opping.
     strategy:
       fail-fast: false
       matrix:
@@ -124,10 +136,10 @@ jobs:
           - extras/configurations/rg-devops-iac
     steps:
       - uses: actions/checkout@v4
-        if: ${{ needs.changes.outputs.terraform == 'true' }}
+        if: ${{ needs.changes.outputs.terraform == 'true' || github.event_name == 'merge_group' }}
 
       - uses: hashicorp/setup-terraform@v3
-        if: ${{ needs.changes.outputs.terraform == 'true' }}
+        if: ${{ needs.changes.outputs.terraform == 'true' || github.event_name == 'merge_group' }}
         with:
           # Matches required_version (~> 1.15.7) in terraform.tf.
           terraform_version: 1.15.7
@@ -136,11 +148,11 @@ jobs:
       # -backend=false downloads providers/initializes modules without
       # configuring remote state, so validation needs no Azure credentials.
       - name: terraform init (no backend)
-        if: ${{ needs.changes.outputs.terraform == 'true' }}
+        if: ${{ needs.changes.outputs.terraform == 'true' || github.event_name == 'merge_group' }}
         run: terraform init -backend=false -input=false
         working-directory: ${{ matrix.dir }}
 
       - name: terraform validate
-        if: ${{ needs.changes.outputs.terraform == 'true' }}
+        if: ${{ needs.changes.outputs.terraform == 'true' || github.event_name == 'merge_group' }}
         run: terraform validate -no-color
         working-directory: ${{ matrix.dir }}


### PR DESCRIPTION
## Problem

The `vnext-merge-queue` repository ruleset forces every merge into `vnext` through the merge queue with an **ALLGREEN** grouping strategy — every required status check must report success on the queue's temporary `merge_group` branch. But **none of the CI workflows listened for the `merge_group` event**, so the required contexts never reported in the queue:

`gitleaks`, `actionlint`, `terraform fmt`, `tflint`, `terraform validate (.)`, `terraform validate (extras/configurations/rg-devops-iac)`, `markdownlint`, `lychee (internal links)`, `PSScriptAnalyzer`, `ShellCheck`.

Queue entries stalled until the 60-minute `check_response_timeout_minutes` expired, then re-queued indefinitely — blocking **every** PR into `vnext` except those merged by ruleset bypass actors. (This is why PR #543 sat in the queue with "nothing happening".)

## Fix

Add a `merge_group: [checks_requested]` trigger to the **six** workflows that produce required contexts. Because the queue branch already contains the merged result, the PR-only `dorny/paths-filter` gate is skipped on `merge_group` and the real checks always run (`|| github.event_name == 'merge_group'`), validating the exact merged tree rather than no-opping.

- `ci-secrets.yml` — gitleaks (already un-gated; trigger only)
- `ci-actions.yml` — actionlint
- `ci-bash.yml` — ShellCheck
- `ci-powershell.yml` — PSScriptAnalyzer
- `ci-docs.yml` — markdownlint + lychee (internal links)
- `ci-terraform.yml` — terraform fmt / tflint / validate matrix

The schedule-only `ci-docs-external-links.yml` is intentionally left unchanged — its `lychee (external links)` context is not a required check.

## Validation

- `actionlint` clean on all six edited workflows.
- YAML parses for all six.
- Preserves the existing "skipped required job satisfies branch protection" behavior on `pull_request`/`push` (path-filter gate unchanged for those events).

## Also included

- `docs`: clarify in `.github/copilot-instructions.md` that the `.vscode/tasks.json` merge task is **Dependabot-only** (filters on `--author "app/dependabot"`, uses `--admin`), not a general "merge all open PRs" task. The instructions file is in markdownlint's ignore list, so no doc lint impact.