### PR TITLE
Fix #544: run vm_mssql_win boot scheduled tasks as SYSTEM

### DIFF
--- a/modules/vm-mssql-win/README.md
+++ b/modules/vm-mssql-win/README.md
@@ -78,9 +78,9 @@ The module is organized as follows:
 ├── scripts/
 |   ├── Configure-FirewallRules.ps1       # Configures Windows firewall rules for SQL Server
 |   ├── Configure-SqlLogin.ps1            # Creates SQL Server login for domain admin and adds it to sysadmin server role
-|   ├── Invoke-MssqlConfiguration.ps1     # Runs Set-MssqlConfiguration.ps1 as domain admin and reboots the VM
-|   ├── Set-MssqlConfiguration.ps1        # Prepares data and log disks and configures SQL Server instance
-|   ├── Set-MssqlStartupConfiguration.ps1 # Re-configures SQL Server tempdb folder after VM stop/deallocate event
+|   ├── Invoke-MssqlConfiguration.ps1     # Runs Set-MssqlConfiguration.ps1 as domain admin, then reboots the VM via a one-time task run as NT AUTHORITY\SYSTEM
+|   ├── Set-MssqlConfiguration.ps1        # Prepares data and log disks and configures SQL Server instance (runs as domain admin); registers the AtStartup task below to run as NT AUTHORITY\SYSTEM
+|   ├── Set-MssqlStartupConfiguration.ps1 # Re-configures the SQL Server tempdb folder after a VM stop/deallocate event; runs as NT AUTHORITY\SYSTEM (local-only work, reliable at boot)
 |   └── Test-VmMssqlWin.ps1               # Unit test script
 ├── compute.tf                            # Compute resource configurations
 ├── locals.tf                             # Local variables

--- a/modules/vm-mssql-win/scripts/Invoke-MssqlConfiguration.ps1
+++ b/modules/vm-mssql-win/scripts/Invoke-MssqlConfiguration.ps1
@@ -145,6 +145,14 @@ if ( -not (Test-Path $scriptPath) ) {
     Exit-WithError "Unable to locate '$scriptPath'..."
 }
 
+# The 'Set-MssqlConfiguration' task runs as the domain admin ON PURPOSE and must stay that way:
+# it performs first-boot SQL configuration that moves the system databases and tempdb using
+# trusted-authentication (Integrated Security) SQL connections, and the domain admin is the
+# SQL sysadmin created earlier by 'Configure-SqlLogin.ps1'. Unlike the AtStartup temp-disk
+# task, this task is started ON-DEMAND during provisioning (Start-ScheduledTask below), so it
+# does not race the domain controller secure channel at boot and is not exposed to the
+# AtStartup domain-logon / Credential Guard failure class. Do NOT switch this task to SYSTEM:
+# SYSTEM is deliberately not a SQL sysadmin, so it could not perform the trusted-auth work.
 Write-ScriptLog "Registering scheduled task '$TaskName' to run '$scriptPath' as '$domainAdminUser'..."
 
 $commandParamParts = @(
@@ -230,8 +238,11 @@ catch {
 }
 
 # Register one-time reboot task to run one minute from now.
+# This task only runs 'Restart-Computer -Force' (a purely local operation), so it runs as
+# 'NT AUTHORITY\SYSTEM' rather than the domain admin. That avoids storing a domain password
+# in the task and avoids any dependence on a domain logon succeeding.
 $rebootTaskRunAt = (Get-Date).AddMinutes(1)
-Write-ScriptLog "Registering one-time reboot scheduled task '$RebootTaskName' to run at '$rebootTaskRunAt' as '$domainAdminUser'..."
+Write-ScriptLog "Registering one-time reboot scheduled task '$RebootTaskName' to run at '$rebootTaskRunAt' as 'NT AUTHORITY\SYSTEM'..."
 
 $rebootTaskAction = New-ScheduledTaskAction `
     -Execute 'powershell.exe' `
@@ -239,15 +250,15 @@ $rebootTaskAction = New-ScheduledTaskAction `
 
 $rebootTaskTrigger = New-ScheduledTaskTrigger -Once -At $rebootTaskRunAt
 
+$rebootTaskPrincipal = New-ScheduledTaskPrincipal -UserId 'NT AUTHORITY\SYSTEM' -LogonType ServiceAccount -RunLevel 'Highest'
+
 try {
     Register-ScheduledTask `
         -Force `
-        -Password $adminPwd `
-        -User $domainAdminUser `
+        -Principal $rebootTaskPrincipal `
         -TaskName $RebootTaskName `
         -Action $rebootTaskAction `
         -Trigger $rebootTaskTrigger `
-        -RunLevel 'Highest' `
         -Description "Force reboot after SQL configuration completes." `
         -ErrorAction Stop
 }

--- a/modules/vm-mssql-win/scripts/Set-MssqlConfiguration.ps1
+++ b/modules/vm-mssql-win/scripts/Set-MssqlConfiguration.ps1
@@ -846,18 +846,25 @@ $taskAction = New-ScheduledTaskAction -Execute 'powershell.exe' -Argument "-Exec
 $taskTrigger = New-ScheduledTaskTrigger -AtStartup
 $taskSettings = New-ScheduledTaskSettingsSet -RestartCount 3 -RestartInterval (New-TimeSpan -Minutes 1)
 
-Write-ScriptLog "Registering scheduled task to execute '$sqlStartupScriptPath' under user '$DomainAdminUser'..."
+Write-ScriptLog "Registering scheduled task to execute '$sqlStartupScriptPath' as 'NT AUTHORITY\SYSTEM'..."
+
+# The startup task performs only local operations (rebuild the ephemeral temp disk stripe,
+# recreate tempdb folders, fix the pagefile, start SQL Server) and never opens a SQL
+# connection, so it does not require the domain admin / SQL sysadmin identity. Run it as
+# LocalSystem: a boot-time (AtStartup) batch logon with a stored domain password is
+# unreliable (it races the domain controller secure channel at boot) and is blocked by
+# Credential Guard (default-on in Windows Server 2025). SYSTEM is a local principal with
+# no stored password and no domain controller dependency, so the task launches reliably.
+$taskPrincipal = New-ScheduledTaskPrincipal -UserId 'NT AUTHORITY\SYSTEM' -LogonType ServiceAccount -RunLevel 'Highest'
 
 try {
     Register-ScheduledTask `
         -Force `
-        -Password $adminPwd `
-        -User $DomainAdminUser `
+        -Principal $taskPrincipal `
         -TaskName $taskName `
         -Action $taskAction `
         -Trigger $taskTrigger `
         -Settings $taskSettings `
-        -RunLevel 'Highest' `
         -Description "Prepare temp drive folders for tempdb and start SQL Server."
 }
 catch {

--- a/modules/vm-mssql-win/scripts/Set-MssqlStartupConfiguration.ps1
+++ b/modules/vm-mssql-win/scripts/Set-MssqlStartupConfiguration.ps1
@@ -10,7 +10,14 @@
 # - MicrosoftSQLServer platform image sql2025-ws2025 entdev-gen2
 # - VM must be pre-configured at first boot using 'Set-MssqlConfiguration.ps1' VM extension script
 # - Default SQL Server instance is configured for manual startup
-# - Runs as domain administrator on the machine being configured
+# - Runs as 'NT AUTHORITY\SYSTEM' (LocalSystem) on the machine being configured. This task
+#   performs only local operations (rebuild the temp-disk stripe, recreate tempdb folders,
+#   fix the pagefile, start the SQL Server services) and never opens a SQL connection, so it
+#   does not require the domain admin / SQL sysadmin identity. It intentionally does NOT run
+#   as a domain account: an AtStartup batch logon with a stored domain password is unreliable
+#   (it races the domain controller secure channel at boot) and is blocked by Credential Guard
+#   (default-on in Windows Server 2025). LocalSystem is a local principal with no stored
+#   password and no domain controller dependency, so the task launches reliably on every boot.
 
 #region constants
 $dataLossWarningReadmeContent = @"

--- a/modules/vm-mssql-win/scripts/Test-VmMssqlWin.ps1
+++ b/modules/vm-mssql-win/scripts/Test-VmMssqlWin.ps1
@@ -102,14 +102,27 @@ catch {
 # fail the remaining tests are meaningless, so we report and exit early.
 $startupOk = $true
 
-# Startup Check 1: Scheduled task last run succeeded
+# Startup Check 1: Scheduled task last run succeeded AND actually ran on this boot
 try {
     $null = Get-ScheduledTask -TaskName 'Set-MssqlStartupConfiguration' -ErrorAction Stop
     $stTaskInfo = Get-ScheduledTaskInfo -TaskName 'Set-MssqlStartupConfiguration' -ErrorAction Stop
 
-    if ($stTaskInfo.LastTaskResult -eq 0) {
-        Write-TestResult $moduleName 'PASS' "Startup: Scheduled task 'Set-MssqlStartupConfiguration' last run succeeded (result: 0, last run: $($stTaskInfo.LastRunTime))"
+    # LastTaskResult alone is not sufficient: when an AtStartup task FAILS TO LAUNCH (e.g. a
+    # domain-logon failure or Credential Guard blocking a stored-password logon), the task body
+    # never runs and LastTaskResult/LastRunTime remain frozen at the PREVIOUS successful boot,
+    # producing a false PASS (this was the root cause of issue #544). Also require that the task
+    # actually ran on the current boot by asserting LastRunTime is after the last OS boot time.
+    $lastBootTime = (Get-CimInstance -ClassName Win32_OperatingSystem -ErrorAction Stop).LastBootUpTime
+    $ranThisBoot = ($null -ne $stTaskInfo.LastRunTime) -and ($stTaskInfo.LastRunTime -gt $lastBootTime)
+
+    if ($stTaskInfo.LastTaskResult -eq 0 -and $ranThisBoot) {
+        Write-TestResult $moduleName 'PASS' "Startup: Scheduled task 'Set-MssqlStartupConfiguration' ran this boot and succeeded (result: 0, last run: $($stTaskInfo.LastRunTime), last boot: $lastBootTime)"
         $passed++
+    }
+    elseif ($stTaskInfo.LastTaskResult -eq 0 -and -not $ranThisBoot) {
+        Write-TestResult $moduleName 'FAIL' "Startup: Scheduled task 'Set-MssqlStartupConfiguration' did not run on the current boot (last run: $($stTaskInfo.LastRunTime) is not after last boot: $lastBootTime). The task likely failed to launch (e.g. domain-logon failure / Credential Guard); its stale success result is a false PASS."
+        $failed++
+        $startupOk = $false
     }
     else {
         Write-TestResult $moduleName 'FAIL' "Startup: Scheduled task 'Set-MssqlStartupConfiguration' last run failed (result: $($stTaskInfo.LastTaskResult), last run: $($stTaskInfo.LastRunTime))"


### PR DESCRIPTION
## Summary

Fixes #544 — SQL Server fails to start after a VM stop/deallocate on `mssqlwin1`.

### Root cause (confirmed via live diagnosis)

The `vm_mssql_win` module registers an `AtStartup` scheduled task, `Set-MssqlStartupConfiguration`, that rebuilds the ephemeral NVMe temp-disk stripe (`T:`), recreates the tempdb folder (`T:\SQLTEMP`), fixes the pagefile, and starts SQL Server after a stop/deallocate. It was registered to run as the **domain admin with a stored password**.

On the post-deallocate boot the task **failed to launch** — TaskScheduler Operational Event 104, `LogonUserExEx` `Error Value: 2147943726` (`0x8007052E ERROR_LOGON_FAILURE`). An `AtStartup` batch logon with a stored domain password:
- races the domain controller secure channel at boot (Netlogon starts the same second), and
- is blocked by **Credential Guard** (default-on in Windows Server 2025).

The task never ran → `T:` was never rebuilt → `MSSQLSERVER` (manual start) stayed stopped → 5 test failures.

### Fix

Run the boot-triggered tasks as `NT AUTHORITY\SYSTEM` — a local principal with no stored password and no DC dependency, immune to Credential Guard. These tasks do only **local** work and never open a SQL connection, so they need no domain admin / SQL sysadmin identity.

- **`Set-MssqlConfiguration.ps1`** — register `Set-MssqlStartupConfiguration` with a SYSTEM principal (was `-User $DomainAdminUser -Password …`).
- **`Set-MssqlStartupConfiguration.ps1`** — header updated to document SYSTEM identity and rationale.
- **`Invoke-MssqlConfiguration.ps1`** — harden the one-time `Set-MssqlConfiguration-Reboot` task (only `Restart-Computer`) to SYSTEM; document that `Set-MssqlConfiguration` intentionally stays domain admin (on-demand, trusted-auth SQL sysadmin work, not boot-triggered).
- **`Test-VmMssqlWin.ps1`** — harden Startup Check 1 to also assert `LastRunTime` is after the last OS boot, catching the **false PASS** where a boot task fails to launch and leaves a stale `LastTaskResult = 0`.
- **`README.md`** — reflect the SYSTEM identity for the startup/reboot tasks.

### End state preserved

Domain-joined VM with SQL Server administered by the domain admin (SQL sysadmin). `Set-MssqlConfiguration.ps1` (first-boot config) is unchanged — it stays domain admin because it moves system DBs/tempdb via trusted-auth (`Integrated Security`) SQL connections and runs **on-demand** during provisioning (not boot-triggered), so it is unaffected by the boot-logon race.

### Sweep of provisioning automation

Reviewed all VM-side automation in `compute.tf` (`join_domain` JsonADDomainExtension, `configure_firewall_rules` / `configure_sql_login` run commands, `configure_sql_server` CustomScriptExtension, `ama`). All are provision-time / one-shot, executed by the Azure guest agent or SYSTEM run commands — none are `AtStartup` domain-credential tasks, and the domain join persists across restarts. The only boot-persistent automation was the two tasks now switched to SYSTEM. No other stored-domain-credential-at-boot pattern exists in the module.

### Validation

- PowerShell parse-check: all 4 changed scripts OK.
- PSScriptAnalyzer: clean on changed code (one pre-existing `Write-Log` warning, unrelated).
- `terraform validate`: success.
- Full re-provision + integration test verification (Scenario 3) to follow.