### PR TITLE
Backport #543: use SQL per-service SID for folder ACLs (vm_mssql_win)

### DIFF
--- a/modules/vm-mssql-win/scripts/Set-MssqlConfiguration.ps1
+++ b/modules/vm-mssql-win/scripts/Set-MssqlConfiguration.ps1
@@ -232,20 +232,21 @@ function Get-MatchingAzureDataDiskBySize {
 function Grant-SqlFullControl {
     param ( [string]$FolderPath )
 
-    Write-ScriptLog "Getting SQL Server Service account..."
+    # Grant FullControl to the SQL Server Database Engine per-service SID rather
+    # than the account returned by querying the service's logon name. The
+    # per-service SID (NT SERVICE\MSSQLSERVER) is always present in the service
+    # process token regardless of the configured logon account, survives service
+    # account changes, and matches the permissions the SQL Server installer
+    # applies to its data directories. The default instance name is MSSQLSERVER,
+    # consistent with the rest of this script.
+    # Reference: https://learn.microsoft.com/sql/database-engine/configure-windows/configure-file-system-permissions-for-database-engine-access
+    $sqlServiceSid = 'NT SERVICE\MSSQLSERVER'
 
-    try {
-        $serviceAccount = Get-CimInstance -ClassName Win32_Service -Filter "Name='MSSQLSERVER'" | Select-Object -ExpandProperty StartName
-    }
-    catch {
-        Exit-WithError $_
-    }
-
-    Write-ScriptLog "Updating ACL for folder '$FolderPath' to allow 'FullControl' for '$serviceAccount'..."
+    Write-ScriptLog "Updating ACL for folder '$FolderPath' to allow 'FullControl' for '$sqlServiceSid'..."
 
     try {
         $folderAcl = Get-ACL $FolderPath
-        $fileSystemAccessRule = New-Object -TypeName System.Security.AccessControl.FileSystemAccessRule( $serviceAccount, "FullControl", 3, 0, "Allow" )
+        $fileSystemAccessRule = New-Object -TypeName System.Security.AccessControl.FileSystemAccessRule( $sqlServiceSid, "FullControl", 3, 0, "Allow" )
         $folderAcl.SetAccessRule( $fileSystemAccessRule )
         Set-Acl -Path $FolderPath -AclObject $folderAcl
     }


### PR DESCRIPTION
Closes #549

## Summary

Backports **theme A** of PR #543 into the production `modules/vm-mssql-win` scripts. `Grant-SqlFullControl` in `Set-MssqlConfiguration.ps1` previously queried the MSSQLSERVER service's logon account (`Get-CimInstance … StartName`) and granted *that account* FullControl on the freshly created SQL data (`$sqlPath`) and errorlog (`$sqlErrorlogPath`) directories.

This change grants FullControl to the Database Engine **per-service SID** `NT SERVICE\MSSQLSERVER` instead. The per-service SID:

- is present in the service process token regardless of the configured logon account,
- survives service-account changes, and
- matches the permissions the SQL Server installer applies to its data directories.

The grant remains **non-destructive** (`SetAccessRule`, inheritance preserved), on directories that are freshly created immediately before the call → low risk.

## Out of scope (from PR #543)

| Theme | Verdict | Why |
|-------|---------|-----|
| B — inheritance disable + clean-slate ACEs | Deferred | Targets live data/errorlog dirs; needs a deploy + `Invoke-UnitTests.ps1 -Module vm_mssql_win -Integration` cycle first. |
| C — `C:\Scripts` lockdown | N/A | CustomScriptExtension delivery; no user-writable `C:\Scripts`. |
| D — encoding/em-dash fix | N/A | Module scripts already ASCII-clean. |
| E — README | N/A | README documents task identity, not the folder-ACL service account. |

## Validation

- PSScriptAnalyzer (CI settings, `-Severity Error,Warning`): **no issues**.
- Non-ASCII scan of edited file: clean.

## Reference

- [Configure File System Permissions for Database Engine Access](https://learn.microsoft.com/sql/database-engine/configure-windows/configure-file-system-permissions-for-database-engine-access)