### PR TITLE
Fix #548: use storage_container_id for azurerm_storage_blob

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -286,8 +286,8 @@ module "vm_mssql_win" {
   location                        = azurerm_resource_group.this.location
   resource_group_name             = azurerm_resource_group.this.name
   storage_account_id              = module.vnet_app[0].resource_ids["storage_account"]
-  storage_account_name            = module.vnet_app[0].resource_names["storage_account"]
   storage_blob_endpoint           = module.vnet_app[0].storage_endpoints["blob"]
+  storage_container_id            = module.vnet_app[0].resource_ids["storage_container"]
   storage_container_name          = module.vnet_app[0].storage_container_name
   subnet_id                       = module.vnet_app[0].subnets["snet-db-01"].id
   tags                            = var.tags

--- a/modules/vm-mssql-win/README.md
+++ b/modules/vm-mssql-win/README.md
@@ -110,7 +110,7 @@ key_vault_name | | The name of the key vault defined in the root module.
 location | | The name of the Azure Region where resources will be provisioned.
 resource_group_name | | The name of the resource group defined in the root module.
 storage_account_id | | The ID of the storage account defined in the vnet-app module.
-storage_account_name | | The name of the storage account defined in the vnet-app module.
+storage_container_id | | The ID of the storage container defined in the vnet-app module.
 storage_container_name | scripts | The name of the storage container defined in the vnet-app module.
 storage_blob_endpoint | | The blob endpoint for the storage account defined in the vnet-app module.
 subnet_id | | The subnet ID defined in the vnet-app module.

--- a/modules/vm-mssql-win/storage.tf
+++ b/modules/vm-mssql-win/storage.tf
@@ -2,11 +2,10 @@
 resource "azurerm_storage_blob" "remote_scripts" {
   for_each = local.remote_scripts
 
-  name                   = each.value.name
-  storage_account_name   = var.storage_account_name
-  storage_container_name = var.storage_container_name
-  type                   = "Block"
-  source                 = "./${path.module}/scripts/${each.value.name}"
+  name                 = each.value.name
+  storage_container_id = var.storage_container_id
+  type                 = "Block"
+  source               = "./${path.module}/scripts/${each.value.name}"
 
   depends_on = [time_sleep.wait_for_roles]
 }

--- a/modules/vm-mssql-win/variables.tf
+++ b/modules/vm-mssql-win/variables.tf
@@ -120,13 +120,13 @@ variable "storage_account_id" {
 
 }
 
-variable "storage_account_name" {
+variable "storage_container_id" {
   type        = string
-  description = "The name of the shared storage account."
+  description = "The ID of the storage container where the remote scripts are stored."
 
   validation {
-    condition     = can(regex("^[a-z0-9]{3,24}$", var.storage_account_name))
-    error_message = "Must conform to Azure storage account naming requirements: it can only contain lowercase letters and numbers, and must be between 3 and 24 characters long."
+    condition     = can(regex("^/subscriptions/[0-9a-fA-F-]+/resourceGroups/[a-zA-Z0-9-_()]+/providers/Microsoft.Storage/storageAccounts/[a-zA-Z0-9]{3,24}/blobServices/default/containers/[a-z0-9]{3,63}$", var.storage_container_id))
+    error_message = "Must be a valid Azure Resource ID for a storage container. It should follow the format '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{storageAccountName}/blobServices/default/containers/{containerName}'."
   }
 }
 

--- a/modules/vnet-app/outputs.tf
+++ b/modules/vnet-app/outputs.tf
@@ -42,6 +42,7 @@ output "resource_names" {
     application_insights     = azurerm_application_insights.this.name
     container_registry       = azurerm_container_registry.this.name
     storage_account          = azurerm_storage_account.this.name
+    storage_container        = azurerm_storage_container.this.name
     storage_share            = azurerm_storage_share.this.name
     virtual_machine_jumpwin1 = azurerm_windows_virtual_machine.this.name
     virtual_network_app      = azurerm_virtual_network.this.name

--- a/modules/vnet-app/outputs.tf
+++ b/modules/vnet-app/outputs.tf
@@ -30,6 +30,7 @@ output "resource_ids" {
     application_insights     = azurerm_application_insights.this.id
     container_registry       = azurerm_container_registry.this.id
     storage_account          = azurerm_storage_account.this.id
+    storage_container        = azurerm_storage_container.this.id
     storage_share            = azurerm_storage_share.this.id
     virtual_machine_jumpwin1 = azurerm_windows_virtual_machine.this.id
     virtual_network_app      = azurerm_virtual_network.this.id

--- a/modules/vnet-app/storage.tf
+++ b/modules/vnet-app/storage.tf
@@ -43,11 +43,10 @@ resource "azurerm_storage_container" "this" {
 resource "azurerm_storage_blob" "remote_scripts" {
   for_each = local.remote_scripts
 
-  name                   = each.value.name
-  storage_account_name   = azurerm_storage_account.this.name
-  storage_container_name = azurerm_storage_container.this.name
-  type                   = "Block"
-  source                 = "./${path.module}/scripts/${each.value.name}"
+  name                 = each.value.name
+  storage_container_id = azurerm_storage_container.this.id
+  type                 = "Block"
+  source               = "./${path.module}/scripts/${each.value.name}"
 
   depends_on = [time_sleep.wait_for_roles]
 }


### PR DESCRIPTION
Closes #548

## Problem
`storage_account_name` and `storage_container_name` on `azurerm_storage_blob` are deprecated in favor of `storage_container_id` and will be removed in v5.0 of the azurerm provider (see the [resource docs](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_blob#storage_account_name)).

## Changes
- **vnet-app**: `azurerm_storage_blob.remote_scripts` now uses `storage_container_id = azurerm_storage_container.this.id`. The container ID is also exposed via `resource_ids["storage_container"]`.
- **vm-mssql-win**: `azurerm_storage_blob.remote_scripts` now uses a new `storage_container_id` input (replacing the now-unused `storage_account_name` input). Wired from the root module via `module.vnet_app[0].resource_ids["storage_container"]`.
- Updated the vm-mssql-win README inputs table.

`storage_container_name` is retained in vm-mssql-win because it is still used to build the run-command `fileUris`.

## Validation
- `terraform validate` — passes (only a pre-existing, unrelated `local_authentication_disabled` deprecation warning).
- `terraform fmt -check` — clean.
- `tflint` — clean.