### PR TITLE
Add expiration date to p2svpn-client-private-key-pem secret

### DIFF
--- a/modules/vwan/main.tf
+++ b/modules/vwan/main.tf
@@ -34,6 +34,11 @@ resource "azurerm_key_vault_secret" "this" {
   value_wo         = tls_private_key.client_cert_key.private_key_pem
   value_wo_version = var.private_key_secret_version
   key_vault_id     = var.key_vault_id
+  expiration_date  = timeadd(timestamp(), "8760h")
+
+  lifecycle {
+    ignore_changes = [expiration_date]
+  }
 }
 
 # Generate a client certificate signed by the root certificate


### PR DESCRIPTION
## Summary

Fixes #545.

The `p2svpn-client-private-key-pem` Key Vault secret in the `vwan` module was created without an expiration date, unlike every other secret in the project which has a one-year expiration.

## Changes

- Added `expiration_date = timeadd(timestamp(), "8760h")` (one year) to the `azurerm_key_vault_secret.this` resource in `modules/vwan/main.tf`.
- Added a `lifecycle { ignore_changes = [expiration_date] }` block so the expiration isn't reset on every plan.

This matches the convention used by the other Key Vault secrets in `modules/vnet-shared/main.tf` and `modules/vm-jumpbox-linux/main.tf`.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>