### PR TITLE
Document exemption-tag handling for the public-access barrier workflow

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -101,7 +101,7 @@ When deploying or modifying a sandbox environment, **do not attempt to automatic
 
 On the first error, stop the workflow immediately and instead:
 
-1. **Document the error.** Capture the exact failing command, the full error output, the step/scenario it occurred in, the enabled modules, and any other relevant context (branch, Terraform/provider versions). Do not retry, re-run, or alter configuration in an attempt to work around it.
+1. **Document the error.** Capture the exact failing command, the full error output, the step/scenario it occurred in, the enabled modules, and any other relevant context (branch, Terraform/provider versions). Do not retry, re-run, or alter configuration in an attempt to work around it. **Sanitize before posting** — Azure error text frequently embeds internal policy names, `aka.ms` wiki links, and subscription/tenant/management-group IDs; genericize them per the [Sanitizing public GitHub content](#sanitizing-public-github-content) rules below.
 2. **Open a GitHub issue** against the repo describing the failure, using the documented details above:
    ```bash
    gh issue create --title "<concise error summary>" --body "<command, full error output, step, context>"
@@ -249,6 +249,20 @@ Modules expose two map outputs used heavily by the root and other modules: `reso
 ## Documentation expectations
 
 Every module has a `README.md` with the same sections: Architecture (drawio SVG in `images/`), Overview, Smoke testing, Documentation (variables / resources / outputs tables). When adding or changing inputs, resources, or outputs, update both the module README and the root README's relevant table.
+
+## Sanitizing public GitHub content
+
+**This is a public repository.** Anything written to a GitHub issue, pull request, comment, review, or commit message is world-readable. Before creating or editing any of these, **strip internal and environment-specific details** — do not make it easy for an outside reader to discover an organization's internal security controls, identities, or topology. This applies to every `gh issue`/`gh pr` create/edit/comment, the auto-filed error-handling issues above, and commit messages.
+
+**Never write these to GitHub; replace each with a generic description:**
+
+- **Specific Azure Policy identifiers** — policy definition names, `policyDefinitionReferenceId`s, assignment names, and initiative names (e.g. a real `*_Modify` policy name or a management-group assignment name). Say "a `modify`-effect Azure Policy" / "an organizational management-group policy assignment" instead.
+- **Internal program / initiative names and internal links** — e.g. an internal security-initiative acronym, or `aka.ms`/internal-wiki URLs echoed back in Azure error text. Remove or generalize them.
+- **Identity and directory GUIDs** — subscription IDs, tenant IDs, management-group IDs, service principal `appId`/`objectId`, user object IDs. Redact to `<subscription>`, `<tenant>`, `<service principal>`, etc.
+- **Per-deployment resource names and host details** — auto-generated sandbox names (`rg-sand-dev-*`, `kv-sand-dev-*`, `st…`), execution-host identifiers (Cloud PC/dev-box VM names), and private IP ranges. Use placeholders like `<resource group>`, `<key vault>`, `<storage account>`.
+- **The concrete exemption tag key/value** — the specific `SecurityControl=Ignore` tag may appear **only** in this `copilot-instructions.md` file (bare-minimum exposure). In issues/PRs/comments/commit messages refer to it generically as "an organization-specific exemption tag" or "the sanctioned allow tag".
+
+**Keep** the genuinely useful, non-identifying technical content: Terraform/module/resource-type names, file paths and line numbers, public Azure resource-provider schema (e.g. `Microsoft.KeyVault/vaults/publicNetworkAccess`), `learn.microsoft.com` doc links, error codes (`ForbiddenByConnection`, HTTP 403), and the generalized root-cause analysis. When in doubt, generalize.
 
 ## Branch / PR notes
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -131,6 +131,14 @@ The barrier pattern leaves Key Vault and Storage Account with public access **di
 ./scripts/enable-public-access.sh
 ```
 
+**MCAPS precheck — verify the `SecurityControl=Ignore` tag on the resource group first (required before `enable-public-access.sh` can work on MCAPS tenants).** On MCAPS tenants a `modify`-effect Azure Policy rewrites Key Vault (and similarly Storage) update requests to force `publicNetworkAccess=Disabled`. The `SecurityControl=Ignore` tag on the resource group (evaluated at RG **or** resource level) exempts resources from this policy. If that tag is **missing** from the RG — e.g. a prior `apply`/`destroy` ran without `-var='additional_tags={SecurityControl="Ignore"}'` and stripped it — then `enable-public-access.sh` will report success but the change is **silently reverted to `Disabled`**, and the next `terraform plan`/`apply` fails with `403 ForbiddenByConnection` on Key Vault data-plane reads/writes. Therefore, **before running `enable-public-access.sh`, confirm the tag exists on the RG**:
+
+```bash
+az group show --name <rg> --query "tags.SecurityControl" -o tsv   # must print: Ignore
+```
+
+If it prints empty/`None`, restore the tag before proceeding (either `az tag update --resource-id <rg id> --operation Merge --tags SecurityControl=Ignore`, or a `terraform apply` with the `additional_tags` var). Only once the tag is present will `enable-public-access.sh` persist and the barrier workflow succeed. Follow the error-handling policy if the tag cannot be restored.
+
 Then perform the `/allow-all`-mode handoff — prompt the user to run `/allow-all` and wait for confirmation — then proceed with `terraform init` (if providers changed) → `terraform plan` → `terraform apply`. The barrier resources will re-disable public access at the end of the apply.
 
 After a successful apply, act on the unit-testing decision captured in preflight item 7. If it was **yes** and a module was **newly enabled**, run that module's unit tests + integration tests (per the scope confirmed in preflight) without re-prompting; if it was **no**, skip this step. **First satisfy the VM-start gate** (`./scripts/manage-vms.sh start`; see the Tests section) — a policy may have deallocated VMs since the apply:

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -252,17 +252,7 @@ Every module has a `README.md` with the same sections: Architecture (drawio SVG 
 
 ## Sanitizing public GitHub content
 
-**This is a public repository.** Anything written to a GitHub issue, pull request, comment, review, or commit message is world-readable. Before creating or editing any of these, **strip internal and environment-specific details** — do not make it easy for an outside reader to discover an organization's internal security controls, identities, or topology. This applies to every `gh issue`/`gh pr` create/edit/comment, the auto-filed error-handling issues above, and commit messages.
-
-**Never write these to GitHub; replace each with a generic description:**
-
-- **Specific Azure Policy identifiers** — policy definition names, `policyDefinitionReferenceId`s, assignment names, and initiative names (e.g. a real `*_Modify` policy name or a management-group assignment name). Say "a `modify`-effect Azure Policy" / "an organizational management-group policy assignment" instead.
-- **Internal program / initiative names and internal links** — e.g. an internal security-initiative acronym, or `aka.ms`/internal-wiki URLs echoed back in Azure error text. Remove or generalize them.
-- **Identity and directory GUIDs** — subscription IDs, tenant IDs, management-group IDs, service principal `appId`/`objectId`, user object IDs. Redact to `<subscription>`, `<tenant>`, `<service principal>`, etc.
-- **Per-deployment resource names and host details** — auto-generated sandbox names (`rg-sand-dev-*`, `kv-sand-dev-*`, `st…`), execution-host identifiers (Cloud PC/dev-box VM names), and private IP ranges. Use placeholders like `<resource group>`, `<key vault>`, `<storage account>`.
-- **The concrete exemption tag key/value** — the specific `SecurityControl=Ignore` tag may appear **only** in this `copilot-instructions.md` file (bare-minimum exposure). In issues/PRs/comments/commit messages refer to it generically as "an organization-specific exemption tag" or "the sanctioned allow tag".
-
-**Keep** the genuinely useful, non-identifying technical content: Terraform/module/resource-type names, file paths and line numbers, public Azure resource-provider schema (e.g. `Microsoft.KeyVault/vaults/publicNetworkAccess`), `learn.microsoft.com` doc links, error codes (`ForbiddenByConnection`, HTTP 403), and the generalized root-cause analysis. When in doubt, generalize.
+This is a **public repo** — issues, PRs, comments, and commit messages are world-readable. Before writing any (including auto-filed error issues), replace internal/environment specifics with generic wording: Azure Policy definition/assignment/initiative names → "a `modify`-effect Azure Policy"; internal program acronyms and `aka.ms`/wiki links → omit; subscription/tenant/management-group IDs, SPN `appId`/`objectId`, user object IDs → `<subscription>`, `<tenant>`, etc.; per-deployment resource names, execution-host names, private IPs → placeholders. The literal `SecurityControl=Ignore` tag may appear **only** in this file — elsewhere call it "an organization-specific exemption tag." Keep non-identifying technical content (resource types, file paths, public ARM schema, `learn.microsoft.com` links, error codes).
 
 ## Branch / PR notes
 

--- a/README.md
+++ b/README.md
@@ -514,8 +514,10 @@ Follow these steps to validate and apply the configuration:
   In some environments, you may need to apply additional tags at the resource group level in order to comply with organizational policies. If you have such a requirement, you can pass your additional tags from the command line like this:
 
   ```bash
-  terraform apply -var='additional_tags={onwer="rob",ticket="AB-123"}'
+  terraform apply -var='additional_tags={owner="rob",ticket="AB-123"}'
   ```
+
+  * **WARNING:** Pass the same `-var='additional_tags=...'` on every `terraform apply`. Omitting it removes any tags you previously added this way.
 
 * Monitor the progress of the apply operation in the console. If errors occur, that may not be reflected in the console immediately. Terraform will try to apply as much of the plan as possible first, then will show the errors when it is done. It can take up to 90 minutes to provision a sandbox depending upon which modules you choose to enable. If everything goes well you should see a message like this:
 


### PR DESCRIPTION
## Summary

Documents how an organization-specific exemption tag interacts with the public-access barrier workflow, in two places:

1. **`.github/copilot-instructions.md`** (Scenario 2) — adds a precheck to verify the resource group carries the required exemption tag **before** running `scripts/enable-public-access.sh`.
2. **`README.md`** (Step 4, apply section) — adds a WARNING that `additional_tags` must be passed on **every** `terraform apply`, plus fixes an `onwer` → `owner` typo.

Refs #564.

## Background

While validating #563, `terraform plan` failed with a `403` connection error on Key Vault even though `enable-public-access.sh` reported success. Root cause:

- Some managed tenants enforce a `modify`-effect Azure Policy that forces Key Vault (and similarly Storage) `publicNetworkAccess=Disabled`.
- An organization-specific exemption tag on the resource group (supplied via the `additional_tags` variable) exempts resources from that policy.
- `azurerm_resource_group.this` manages `tags` authoritatively (`tags = merge(var.tags, var.additional_tags)`, no `ignore_changes`), so a `terraform apply` run **without** the same `-var='additional_tags=...'` deletes the tag from the resource group.
- With the tag gone, `enable-public-access.sh` succeeds but the policy silently reverts public access, and the next plan/apply fails.

See #564 for the full investigation.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>