### PR TITLE
Document rg-devops-iac (jumplinux2) as a second Terraform execution environment

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -12,7 +12,7 @@ Terraform IaC project that provisions a modular Azure sandbox environment. Not f
 
 ## Build / validate / test
 
-Run from repo root. Terraform state lives locally by default (sensitive — see README about adding `backend.tf`).
+Run from repo root. Terraform state lives locally by default (sensitive — see README about adding `backend.tf`, and the "Terraform execution environments" section below for the jumplinux2/rg-devops-iac remote-backend case).
 
 ```bash
 terraform init
@@ -31,6 +31,40 @@ The SPN password must come from the env var `TF_VAR_arm_client_secret` — never
 ```
 
 For example: `terraform apply -var='additional_tags={SecurityControl="Ignore"}'`. To add more MCAPS tags, include them in the same map, e.g. `-var='additional_tags={SecurityControl="Ignore",owner="rob"}'`. Keys in `additional_tags` win on collisions with the base `tags` map.
+
+## Terraform execution environments
+
+Two Terraform execution environments are in active use for this repo — identify which one a session is running in before touching Terraform state:
+
+- **WSL / local client** (default): Terraform state is local (`terraform.tfstate` in the repo root, git-ignored). No `backend.tf`. All auth (`azurerm`/`azuread`/`azapi` providers in `providers.tf`) is SPN-based via `TF_VAR_arm_client_secret`. The generic `backend.tf` example in the root README applies here if a user opts into a remote backend manually.
+- **`jumplinux2`** — the VM deployed by `extras/configurations/rg-devops-iac`, reached via VS Code Remote-SSH. Detect it with `hostname` (`jumplinux2`) or `echo $ARM_USE_MSI` (pre-set `true` by cloud-init, along with `$ARM_TENANT_ID`). Provider auth in `providers.tf` stays SPN-based and unchanged — only the Terraform **state backend** differs: it uses the `azurerm` backend with Azure AD / managed-identity auth against the rg-devops-iac storage account (`tfstate` container), which grants jumplinux2's managed identity `Storage Blob Data Contributor`.
+
+  If `backend.tf` doesn't already exist in the repo root, create it — never overwrite one that's already there. Look up the current values live (they vary per rg-devops-iac deployment, so never hardcode them in docs or configs): prefer the **Azure MCP server** tools available in this session — `azure-subscription_list` for the subscription id, `azure-group_list` / `azure-group_resource_list` to find the rg-devops-iac resource group and its lone storage account, `azure-storage` to confirm the storage account name — falling back to Azure CLI only if the MCP server isn't wired up:
+
+  ```bash
+  SUBSCRIPTION_ID=$(az account show --query id -o tsv)
+  RG=$(az group list --query "[?starts_with(name, 'rg-devops-')].name" -o tsv | head -1)
+  STORAGE_ACCOUNT=$(az storage account list -g "$RG" --query "[0].name" -o tsv)
+  ```
+
+  Then write:
+
+  ```hcl
+  # backend.tf
+  terraform {
+    backend "azurerm" {
+      use_azuread_auth     = true
+      use_msi              = true
+      tenant_id            = "<$ARM_TENANT_ID>"
+      subscription_id      = "<$SUBSCRIPTION_ID>"
+      storage_account_name = "<$STORAGE_ACCOUNT>"
+      container_name       = "tfstate"
+      key                  = "azuresandbox.tfstate"
+    }
+  }
+  ```
+
+  `backend.tf` is git-ignored (values are environment-specific). Run `terraform init` (add `-reconfigure` if migrating from local state) after creating/changing it.
 
 ## Preflight checklist (run attended, before enabling `/allow-all` mode for any apply or test work)
 
@@ -61,6 +95,7 @@ The intended workflow is a clean two-phase handoff:
    - **Known gotcha — empty `user_name`:** the script derives the `user_name` default from `az ad user show --id <user_object_id> --query userPrincipalName` (where `user_object_id` is the JWT `oid` claim). When the signed-in identity lacks Microsoft Entra directory read permission (common for guest accounts and many service-principal-style admin logins), that lookup returns **empty**, so the prompt has no default and a non-interactive run (piping an empty line) writes `user_name = ""` to `terraform.tfvars`. This **fails the `user_name` UPN-format validation in `variables.tf`** at `terraform plan`/`apply`. After running `bootstrap.sh`, **always verify `user_name` is a non-empty valid UPN** (`grep '^user_name' terraform.tfvars`); if it is blank, set it explicitly — get the UPN from `az ad signed-in-user show --query userPrincipalName -o tsv` (or `az account show --query user.name -o tsv` as a fallback) and edit `terraform.tfvars`. When driving the script non-interactively, prefer supplying the UPN explicitly for the `user_name` prompt rather than relying on the (possibly empty) default.
    - **Output** — it (over)writes `./terraform.tfvars` in the repo root containing `aad_tenant_id`, `arm_client_id`, `location`, `subscription_id`, `user_name`, `user_object_id`, a `tags` map (`project`/`costcenter`/`environment`), and **all `enable_module_*` toggles commented out (every module disabled by default)**. Module enablement is therefore handled separately in preflight item 6 by editing `terraform.tfvars` afterward — `bootstrap.sh` never enables a module. Note it does **not** prompt for or write the SPN secret (that stays in `TF_VAR_arm_client_secret`).
    - **To drive it non-interactively** (e.g. when you already have every value), pipe the answers to stdin in prompt order — `arm_client_id`, `aad_tenant_id`, `user_name`, `user_object_id`, `subscription_id`, `location`, `environment`, `costcenter`, `project` — e.g. `printf '%s\n' "$appid" "" "" "" "" "" "" "" "" | ./scripts/bootstrap.sh` (empty lines accept the defaults). Prefer the attended interactive flow unless the user has supplied all inputs.
+5. **Terraform execution environment identified** — determine whether this session is on **WSL / local client** or **`jumplinux2`** (rg-devops-iac), per the "Terraform execution environments" section above. On jumplinux2 with no `backend.tf` yet, look up the backend values and create it before `terraform init`; leave an existing `backend.tf` untouched. On WSL, no action needed (local state is the default).
 6. **Module enablement confirmed** — use `ask_user` to ask whether **all base modules** in `./modules` should be deployed (every `enable_module_*` flag `true`). Extra modules in `./extras/modules` (`ai-foundry`, `avd`, `petstore`, `vnet-onprem`, etc.) are **always excluded** from this question and left **disabled**. If the answer is **no**, use `ask_user` again to have the user specify exactly which base modules to enable (e.g. `vnet_app` only); all other base modules stay disabled. Confirm the selection before editing `terraform.tfvars`.
 7. **Automated unit testing decision** — use `ask_user` to ask whether automated unit tests (`Invoke-UnitTests.ps1`) should be run after a successful `terraform apply`. Capture this decision now, batched with the other preflight prompts, because it determines whether preflight item 3 (Azure PowerShell auth) is required — that human-gated input must be collected up front, not after the `/allow-all`-mode handoff. If the answer is **yes**, also confirm scope: all installed modules (`Invoke-UnitTests.ps1`, which runs each installed module's unit **and** integration tests automatically) versus a single module's unit tests, optionally with its integration tests (`-Module <name> [-Integration]` — `-Integration` applies only to a single-module run). If the answer is **no**, record it and skip item 3 (unless otherwise needed). The recorded decision drives the post-apply test step in Scenarios 1 and 2 — do not re-prompt for it after the apply.
 8. **MCAPS tenant tagging** — confirm whether the target subscription is on an **MCAPS tenant** (the default assumption for this environment; the tenant in use here is MCAPS). If yes, **every** `terraform plan` and `terraform apply` command in every scenario below must include `-var='additional_tags={SecurityControl="Ignore"}'` so the `SecurityControl=Ignore` tag is merged over the base `tags` map and Azure Policy does not deny the apply. Record this decision now so the flag is applied consistently across the run without re-prompting. Do not edit `terraform.tfvars` for this — pass it on the command line.

--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,10 @@ crash.log
 #
 *.tfvars
 
+# Ignore backend.tf - remote state backend configuration is environment-specific
+# (e.g. differs between a WSL client and the rg-devops-iac jumplinux2 environment)
+backend.tf
+
 # Trace files
 terraform.log
 

--- a/extras/configurations/rg-devops-iac/README.md
+++ b/extras/configurations/rg-devops-iac/README.md
@@ -308,6 +308,14 @@ You now have a fully provisioned DevOps IaC environment! You can use it as a Ter
 
 Don't forget to delete your DevOps IaC environment when you're done. You don't want to have to explain to your boss why you left an unused resources laying around that costs your company money. The quickest way to clean up is to delete the DevOps IaC resource group. Do this with care because data loss will occur, including any Terraform state files in the Azure Blob Storage container.
 
+If you only need to remove Terraform state file(s) from the Azure Blob Storage container without deleting the whole environment, use `scripts/delete-tfstate.sh`. It authenticates with Azure CLI / Microsoft Entra ID only (the storage account has shared access keys disabled) and relies on the built-in RBAC role assignments granted to the caller (e.g. jumplinux2's managed identity) to delete blobs over the storage account's private endpoint — it does not enable public network access, so it must be run from a host with private network connectivity to the storage account, such as jumplinux2. Run it with no arguments to list and select blob(s) interactively, or pass a blob name (e.g. `azuresandbox.tfstate`) to delete it directly:
+
+```bash
+./scripts/delete-tfstate.sh                       # list and select interactively
+./scripts/delete-tfstate.sh azuresandbox.tfstate  # delete a specific blob
+./scripts/delete-tfstate.sh --yes azuresandbox.tfstate  # skip confirmation prompt
+```
+
 ## Documentation
 
 This section provides documentation regarding the overall structure of the root module for this configuration. See the README.md files in each module directory for more information about that module.
@@ -330,7 +338,10 @@ This configuration is organized into the following structure:
 │   └── vm-jumpbox-linux/                 # Linux jumpbox virtual machine module
 ├── scripts/                              # 
 │   ├── bootstrap.sh                      # Bash helper script for generating terraform.tfvars
-│   └── bootstrap.ps1                     # PowerShell helper script for generating terraform.tfvars
+│   ├── bootstrap.ps1                     # PowerShell helper script for generating terraform.tfvars
+│   ├── cleanterraformtemp.sh             # Bash helper script for removing Terraform temp/local files
+│   ├── enable-public-access.sh           # Bash helper script for re-enabling public access on key vault/storage account
+│   └── delete-tfstate.sh                 # Bash helper script for deleting Terraform state blob(s) from the storage backend
 ├── locals.tf                             # Local variables 
 ├── main.tf                               # Resource configurations
 ├── network.tf                            # Network resource blocks

--- a/extras/configurations/rg-devops-iac/scripts/delete-tfstate.sh
+++ b/extras/configurations/rg-devops-iac/scripts/delete-tfstate.sh
@@ -1,0 +1,238 @@
+#!/bin/bash
+
+# Deletes Terraform state blob(s) from the tfstate container in the
+# rg-devops-iac storage account, used as a remote state backend for other
+# Terraform configurations (e.g. the root azuresandbox module running from
+# jumplinux2).
+#
+# This does NOT use 'terraform output' because the state being deleted here
+# is not the state of the rg-devops-iac configuration itself -- it's other
+# Terraform state stored in that account's blob container.
+#
+# Authentication is via Azure CLI / Microsoft Entra ID only (the storage
+# account has shared_access_key_enabled = false), using '--auth-mode login'
+# for every 'az storage blob' call. This relies on the caller's identity
+# (typically jumplinux2's managed identity, or a signed-in user/SPN) having
+# a data-plane role assignment on the storage account, such as
+# 'Storage Blob Data Contributor' (see azurerm_role_assignment.storage_roles
+# in storage.tf).
+#
+# The storage account's blob service is only reachable over its private
+# endpoint. This script assumes it is being run from a host on the same
+# virtual network as that private endpoint (e.g. jumplinux2) -- it does NOT
+# enable public network access, and will fail if run from a host without
+# private network connectivity and public access is disabled.
+
+set -euo pipefail
+
+SCRIPT_NAME="$(basename "${BASH_SOURCE[0]}")"
+
+CONTAINER_NAME="tfstate"
+RESOURCE_GROUP=""
+STORAGE_ACCOUNT=""
+BLOB_NAME=""
+ASSUME_YES=false
+
+usage() {
+  cat <<EOF
+Usage: ${SCRIPT_NAME} [blob-name] [options]
+
+Deletes Terraform state blob(s) from the tfstate container in the
+rg-devops-iac storage account.
+
+Arguments:
+  blob-name                    Name of a specific blob to delete (e.g.
+                                azuresandbox.tfstate). If omitted, the script
+                                lists all blobs in the container and prompts
+                                for a selection.
+
+Options:
+  --resource-group <name>      Resource group containing the storage account.
+                                Default: auto-discovered (first resource
+                                group whose name starts with 'rg-devops-').
+  --storage-account <name>     Storage account name. Default: auto-discovered
+                                (first storage account found in the resource
+                                group).
+  --container <name>           Blob container name. Default: tfstate.
+  -y, --yes                    Skip the interactive confirmation prompt.
+  -h, --help                   Show this help message and exit.
+
+Examples:
+  ${SCRIPT_NAME} azuresandbox.tfstate
+  ${SCRIPT_NAME} --yes azuresandbox.tfstate
+  ${SCRIPT_NAME}
+EOF
+}
+
+# --- Parse arguments ---
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --resource-group)
+      RESOURCE_GROUP="$2"
+      shift 2
+      ;;
+    --storage-account)
+      STORAGE_ACCOUNT="$2"
+      shift 2
+      ;;
+    --container)
+      CONTAINER_NAME="$2"
+      shift 2
+      ;;
+    -y|--yes)
+      ASSUME_YES=true
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    -*)
+      echo "Error: Unknown option '$1'" >&2
+      usage
+      exit 1
+      ;;
+    *)
+      if [[ -n "${BLOB_NAME}" ]]; then
+        echo "Error: Multiple blob names specified ('${BLOB_NAME}' and '$1')." >&2
+        exit 1
+      fi
+      BLOB_NAME="$1"
+      shift
+      ;;
+  esac
+done
+
+# --- Verify Azure CLI authentication ---
+if ! az account show >/dev/null 2>&1; then
+  echo "Error: Not signed in to Azure CLI. Run 'az login' (or ensure MSI is configured) and try again." >&2
+  exit 1
+fi
+
+# --- Discover resource group ---
+if [[ -z "${RESOURCE_GROUP}" ]]; then
+  RESOURCE_GROUP=$(az group list --query "[?starts_with(name, 'rg-devops-')].name" -o tsv | head -1)
+  if [[ -z "${RESOURCE_GROUP}" ]]; then
+    echo "Error: Failed to auto-discover a resource group starting with 'rg-devops-'." >&2
+    echo "Specify one explicitly with --resource-group <name>." >&2
+    exit 1
+  fi
+  echo "Using resource group: ${RESOURCE_GROUP}"
+fi
+
+# --- Discover storage account ---
+if [[ -z "${STORAGE_ACCOUNT}" ]]; then
+  STORAGE_ACCOUNT=$(az storage account list -g "${RESOURCE_GROUP}" --query "[0].name" -o tsv)
+  if [[ -z "${STORAGE_ACCOUNT}" ]]; then
+    echo "Error: Failed to auto-discover a storage account in resource group '${RESOURCE_GROUP}'." >&2
+    echo "Specify one explicitly with --storage-account <name>." >&2
+    exit 1
+  fi
+  echo "Using storage account: ${STORAGE_ACCOUNT}"
+fi
+
+echo "Using container: ${CONTAINER_NAME}"
+echo ""
+
+confirm() {
+  local prompt="$1"
+  if [[ "${ASSUME_YES}" == true ]]; then
+    return 0
+  fi
+  read -r -p "${prompt} [y/N] " REPLY
+  [[ "${REPLY}" =~ ^[Yy]$ ]]
+}
+
+delete_blob() {
+  local blob="$1"
+  echo "Deleting blob '${blob}' from container '${CONTAINER_NAME}'..."
+  az storage blob delete \
+    --account-name "${STORAGE_ACCOUNT}" \
+    --container-name "${CONTAINER_NAME}" \
+    --name "${blob}" \
+    --auth-mode login \
+    --output none
+  echo "  Deleted."
+}
+
+if [[ -n "${BLOB_NAME}" ]]; then
+  # --- Single named blob mode ---
+  if ! az storage blob show \
+    --account-name "${STORAGE_ACCOUNT}" \
+    --container-name "${CONTAINER_NAME}" \
+    --name "${BLOB_NAME}" \
+    --auth-mode login \
+    --output none 2>/dev/null; then
+    echo "Error: Blob '${BLOB_NAME}' not found in container '${CONTAINER_NAME}'." >&2
+    exit 1
+  fi
+
+  if confirm "Delete blob '${BLOB_NAME}' from '${STORAGE_ACCOUNT}/${CONTAINER_NAME}'? This cannot be undone."; then
+    delete_blob "${BLOB_NAME}"
+  else
+    echo "Aborted. No blobs were deleted."
+    exit 0
+  fi
+else
+  # --- Interactive list-and-select mode ---
+  echo "Listing blobs in '${STORAGE_ACCOUNT}/${CONTAINER_NAME}'..."
+  mapfile -t BLOBS < <(az storage blob list \
+    --account-name "${STORAGE_ACCOUNT}" \
+    --container-name "${CONTAINER_NAME}" \
+    --auth-mode login \
+    --query "[].name" -o tsv)
+
+  if [[ ${#BLOBS[@]} -eq 0 ]]; then
+    echo "No blobs found in container '${CONTAINER_NAME}'. Nothing to delete."
+    exit 0
+  fi
+
+  echo ""
+  echo "Blobs found:"
+  for i in "${!BLOBS[@]}"; do
+    printf "  %d) %s\n" "$((i + 1))" "${BLOBS[$i]}"
+  done
+  echo "  a) All blobs"
+  echo "  q) Cancel"
+  echo ""
+
+  read -r -p "Select a blob to delete by number, 'a' for all, or 'q' to cancel: " SELECTION
+
+  case "${SELECTION}" in
+    q|Q)
+      echo "Cancelled. No blobs were deleted."
+      exit 0
+      ;;
+    a|A)
+      if confirm "Delete ALL ${#BLOBS[@]} blob(s) from '${STORAGE_ACCOUNT}/${CONTAINER_NAME}'? This cannot be undone."; then
+        for blob in "${BLOBS[@]}"; do
+          delete_blob "${blob}"
+        done
+      else
+        echo "Aborted. No blobs were deleted."
+        exit 0
+      fi
+      ;;
+    ''|*[!0-9]*)
+      echo "Error: Invalid selection '${SELECTION}'." >&2
+      exit 1
+      ;;
+    *)
+      INDEX=$((SELECTION - 1))
+      if [[ ${INDEX} -lt 0 || ${INDEX} -ge ${#BLOBS[@]} ]]; then
+        echo "Error: Selection '${SELECTION}' is out of range." >&2
+        exit 1
+      fi
+      SELECTED_BLOB="${BLOBS[$INDEX]}"
+      if confirm "Delete blob '${SELECTED_BLOB}' from '${STORAGE_ACCOUNT}/${CONTAINER_NAME}'? This cannot be undone."; then
+        delete_blob "${SELECTED_BLOB}"
+      else
+        echo "Aborted. No blobs were deleted."
+        exit 0
+      fi
+      ;;
+  esac
+fi
+
+echo ""
+echo "Done."


### PR DESCRIPTION
## Summary

Documents a second Terraform execution environment in `.github/copilot-instructions.md`: the `jumplinux2` VM provisioned by `extras/configurations/rg-devops-iac`, accessed via VS Code Remote-SSH, as distinct from the existing default WSL/local-client environment.

Closes #569.

## Changes

- New "Terraform execution environments" section distinguishing:
  - **WSL / local client** (default): local Terraform state, no `backend.tf`, SPN-based auth via an environment-variable-sourced service principal secret.
  - **`jumplinux2`**: provider auth (`providers.tf`) remains SPN-based and unchanged; only the Terraform **state backend** differs — it uses the `azurerm` backend with Azure AD / managed-identity auth against the rg-devops-iac storage account's `tfstate` container.
- Documents a lookup recipe for backend values (subscription id, resource group, storage account name), preferring Azure MCP server tools available in a Copilot CLI session, with an Azure CLI fallback. No environment-specific values are hardcoded as examples — they're always looked up live.
- Adds a preflight checklist item (filling a pre-existing numbering gap, so the checklist is now 1–8) to identify which execution environment a session is in and, on `jumplinux2`, create `backend.tf` if missing (never overwriting an existing one).
- Updates `.gitignore` to exclude `backend.tf`, since its values are environment-specific (same treatment as `*.tfvars`).

## Scope notes

- Provider auth blocks in `providers.tf` are intentionally unchanged (still SPN-based) — this is a state-backend-only change.
- `extras/configurations/rg-devops-iac` itself is out of scope; it continues to use local state.
- The root `README.md`'s existing generic `backend.tf` example was left as-is; the new guidance is cross-linked as environment-specific and complementary rather than a replacement.

## Testing

Documentation-only change; no Terraform validate/plan/apply required. Verified Markdown renders correctly and preflight item numbering is consecutive (1–8) after the edit.