### PR TITLE
Fix deprecated local_authentication_disabled argument in vnet-app module

### DIFF
--- a/modules/vnet-app/main.tf
+++ b/modules/vnet-app/main.tf
@@ -62,14 +62,14 @@ resource "azurerm_monitor_diagnostic_setting" "container_registry" {
 # start enabled and are flipped to Disabled by the root azapi_update_resource after the
 # AMPLS access barrier signals end-to-end wiring is complete (see root main.tf).
 resource "azurerm_application_insights" "this" {
-  name                          = module.naming.application_insights.name_unique
-  location                      = var.location
-  resource_group_name           = var.resource_group_name
-  application_type              = "web"
-  workspace_id                  = var.log_analytics_workspace_id
-  local_authentication_disabled = true
-  internet_ingestion_enabled    = true
-  internet_query_enabled        = true
+  name                         = module.naming.application_insights.name_unique
+  location                     = var.location
+  resource_group_name          = var.resource_group_name
+  application_type             = "web"
+  workspace_id                 = var.log_analytics_workspace_id
+  local_authentication_enabled = false
+  internet_ingestion_enabled   = true
+  internet_query_enabled       = true
 
   lifecycle {
     ignore_changes = [internet_ingestion_enabled, internet_query_enabled]


### PR DESCRIPTION
## Summary
Replaces the deprecated `local_authentication_disabled` argument with `local_authentication_enabled` on `azurerm_application_insights.this` in the `vnet-app` module, ahead of its removal in AzureRM provider v5.0.

## Changes
- `modules/vnet-app/main.tf`: `local_authentication_disabled = true` → `local_authentication_enabled = false`

## Validation
- `terraform init -backend=false` + `terraform validate`: Success, no deprecation warning.

Fixes #571