### PR TITLE
Migrate rg-devops-iac config to azurerm 5.0

### DIFF
--- a/extras/configurations/rg-devops-iac/modules/vm-jumpbox-linux/terraform.tf
+++ b/extras/configurations/rg-devops-iac/modules/vm-jumpbox-linux/terraform.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 4.81.0"
+      version = "~> 5.0.1"
     }
 
     cloudinit = {

--- a/extras/configurations/rg-devops-iac/network.tf
+++ b/extras/configurations/rg-devops-iac/network.tf
@@ -68,20 +68,18 @@ resource "azurerm_private_dns_zone" "storage_blob" {
 }
 
 resource "azurerm_private_dns_zone_virtual_network_link" "key_vault" {
-  name                  = "link-${azurerm_private_dns_zone.key_vault.name}-${azurerm_virtual_network.this.name}"
-  resource_group_name   = azurerm_resource_group.this.name
-  private_dns_zone_name = azurerm_private_dns_zone.key_vault.name
-  virtual_network_id    = azurerm_virtual_network.this.id
-  resolution_policy     = "NxDomainRedirect"
+  name                = "link-${azurerm_private_dns_zone.key_vault.name}-${azurerm_virtual_network.this.name}"
+  private_dns_zone_id = azurerm_private_dns_zone.key_vault.id
+  virtual_network_id  = azurerm_virtual_network.this.id
+  resolution_policy   = "NxDomainRedirect"
 }
 
 
 resource "azurerm_private_dns_zone_virtual_network_link" "storage_blob" {
-  name                  = "link-${azurerm_private_dns_zone.storage_blob.name}-${azurerm_virtual_network.this.name}"
-  resource_group_name   = azurerm_resource_group.this.name
-  private_dns_zone_name = azurerm_private_dns_zone.storage_blob.name
-  virtual_network_id    = azurerm_virtual_network.this.id
-  resolution_policy     = "NxDomainRedirect"
+  name                = "link-${azurerm_private_dns_zone.storage_blob.name}-${azurerm_virtual_network.this.name}"
+  private_dns_zone_id = azurerm_private_dns_zone.storage_blob.id
+  virtual_network_id  = azurerm_virtual_network.this.id
+  resolution_policy   = "NxDomainRedirect"
 }
 #endregion
 

--- a/extras/configurations/rg-devops-iac/terraform.tf
+++ b/extras/configurations/rg-devops-iac/terraform.tf
@@ -9,7 +9,7 @@ terraform {
 
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 4.81.0"
+      version = "~> 5.0.1"
     }
 
     cloudinit = {


### PR DESCRIPTION
## Summary

Migrates the **`extras/configurations/rg-devops-iac`** standalone configuration (and its `vm-jumpbox-linux` child module) from `azurerm ~> 4.81.0` to `~> 5.0.1`, including the required azurerm 5.0 code change.

This supersedes the two Dependabot PRs for this config (#581, #583), which only raised the version constraint and would fail `terraform validate` under 5.0 without the code fix. The provider bump and code fix are coupled (the new syntax is 5.0-only and the old syntax is 4.x-only), so they must land together.

## Changes

- `terraform.tf` (config root) and `modules/vm-jumpbox-linux/terraform.tf`: `azurerm` constraint `~> 4.81.0` -> `~> 5.0.1`.
- `network.tf`: `azurerm_private_dns_zone_virtual_network_link` (`key_vault` and `storage_blob`) now use the required `private_dns_zone_id` argument instead of the removed `resource_group_name` + `private_dns_zone_name` pair (azurerm 5.0 breaking change).

## Validation

- `terraform init` resolves `azurerm v5.0.1`.
- `terraform validate` -> **Success! The configuration is valid.**
- `tflint` (recommended + azurerm ruleset) -> **no findings**.

## Related

- Addresses #588 for the `rg-devops-iac` config.
- Supersedes Dependabot PRs #581 and #583 (can be closed once this merges).
- Issue #589 (Log Analytics) does **not** affect this config.