### PR TITLE
Migrate root sandbox config to azurerm 5.0

### DIFF
--- a/extras/modules/avd/terraform.tf
+++ b/extras/modules/avd/terraform.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 4.81.0"
+      version = "~> 5.0.1"
     }
 
     time = {

--- a/extras/modules/petstore/terraform.tf
+++ b/extras/modules/petstore/terraform.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 4.81.0"
+      version = "~> 5.0.1"
     }
 
     null = {

--- a/extras/modules/vnet-onprem/terraform.tf
+++ b/extras/modules/vnet-onprem/terraform.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 4.81.0"
+      version = "~> 5.0.1"
     }
 
     time = {

--- a/modules/mssql/terraform.tf
+++ b/modules/mssql/terraform.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 4.81.0"
+      version = "~> 5.0.1"
     }
 
     random = {

--- a/modules/mysql/terraform.tf
+++ b/modules/mysql/terraform.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 4.81.0"
+      version = "~> 5.0.1"
     }
 
     random = {

--- a/modules/vm-jumpbox-linux/terraform.tf
+++ b/modules/vm-jumpbox-linux/terraform.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 4.81.0"
+      version = "~> 5.0.1"
     }
 
     cloudinit = {

--- a/modules/vm-mssql-win/terraform.tf
+++ b/modules/vm-mssql-win/terraform.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 4.81.0"
+      version = "~> 5.0.1"
     }
 
     random = {

--- a/modules/vnet-app/main.tf
+++ b/modules/vnet-app/main.tf
@@ -35,7 +35,6 @@ resource "azurerm_container_registry" "this" {
   public_network_access_enabled = false
   quarantine_policy_enabled     = false
   retention_policy_in_days      = 7
-  trust_policy_enabled          = false
   zone_redundancy_enabled       = false
 
   lifecycle {

--- a/modules/vnet-app/network.tf
+++ b/modules/vnet-app/network.tf
@@ -108,30 +108,27 @@ resource "azurerm_private_dns_zone" "zones" {
 }
 
 resource "azurerm_private_dns_zone_virtual_network_link" "vnet_app_links" {
-  for_each              = azurerm_private_dns_zone.zones
-  name                  = "link-${each.value.name}-${azurerm_virtual_network.this.name}"
-  resource_group_name   = var.resource_group_name
-  private_dns_zone_name = each.value.name
-  virtual_network_id    = azurerm_virtual_network.this.id
-  depends_on            = [azurerm_virtual_network_peering.app_to_shared, azurerm_virtual_network_peering.shared_to_app]
+  for_each            = azurerm_private_dns_zone.zones
+  name                = "link-${each.value.name}-${azurerm_virtual_network.this.name}"
+  private_dns_zone_id = each.value.id
+  virtual_network_id  = azurerm_virtual_network.this.id
+  depends_on          = [azurerm_virtual_network_peering.app_to_shared, azurerm_virtual_network_peering.shared_to_app]
 }
 
 resource "azurerm_private_dns_zone_virtual_network_link" "vnet_app_links_from_vnet_shared" {
-  for_each              = var.private_dns_zones_vnet_shared
-  name                  = "link-${each.value.name}-${azurerm_virtual_network.this.name}"
-  resource_group_name   = var.resource_group_name
-  private_dns_zone_name = each.value.name
-  virtual_network_id    = azurerm_virtual_network.this.id
-  depends_on            = [azurerm_virtual_network_peering.app_to_shared, azurerm_virtual_network_peering.shared_to_app]
+  for_each            = var.private_dns_zones_vnet_shared
+  name                = "link-${each.value.name}-${azurerm_virtual_network.this.name}"
+  private_dns_zone_id = each.value.id
+  virtual_network_id  = azurerm_virtual_network.this.id
+  depends_on          = [azurerm_virtual_network_peering.app_to_shared, azurerm_virtual_network_peering.shared_to_app]
 }
 
 resource "azurerm_private_dns_zone_virtual_network_link" "vnet_shared_links" {
-  for_each              = azurerm_private_dns_zone.zones
-  name                  = "link-${each.value.name}-${var.virtual_network_shared_name}"
-  resource_group_name   = var.resource_group_name
-  private_dns_zone_name = each.value.name
-  virtual_network_id    = var.virtual_network_shared_id
-  depends_on            = [azurerm_virtual_network_peering.app_to_shared, azurerm_virtual_network_peering.shared_to_app]
+  for_each            = azurerm_private_dns_zone.zones
+  name                = "link-${each.value.name}-${var.virtual_network_shared_name}"
+  private_dns_zone_id = each.value.id
+  virtual_network_id  = var.virtual_network_shared_id
+  depends_on          = [azurerm_virtual_network_peering.app_to_shared, azurerm_virtual_network_peering.shared_to_app]
 }
 #endregion
 

--- a/modules/vnet-app/terraform.tf
+++ b/modules/vnet-app/terraform.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 4.81.0"
+      version = "~> 5.0.1"
     }
 
     random = {

--- a/modules/vnet-shared/main.tf
+++ b/modules/vnet-shared/main.tf
@@ -72,25 +72,21 @@ resource "azurerm_monitor_diagnostic_setting" "this" {
   enabled_log {
     category_group = "audit"
   }
-
-  lifecycle {
-    ignore_changes = [metric]
-  }
 }
 #endregion
 
 #region azure-monitor
 resource "azurerm_log_analytics_workspace" "this" {
-  name                       = module.naming.log_analytics_workspace.name_unique
-  location                   = var.location
-  resource_group_name        = var.resource_group_name
-  sku                        = "PerGB2018"
-  retention_in_days          = var.log_analytics_workspace_retention_days
-  internet_ingestion_enabled = true # Starts enabled; root main.tf barrier disables after all modules complete
-  internet_query_enabled     = true # Starts enabled; root main.tf barrier disables after all modules complete
+  name                           = module.naming.log_analytics_workspace.name_unique
+  location                       = var.location
+  resource_group_name            = var.resource_group_name
+  sku                            = "PerGB2018"
+  retention_in_days              = var.log_analytics_workspace_retention_days
+  internet_ingestion_access_type = "Enabled" # Starts enabled; root main.tf barrier disables after all modules complete
+  internet_query_access_type     = "Enabled" # Starts enabled; root main.tf barrier disables after all modules complete
 
   lifecycle {
-    ignore_changes = [internet_ingestion_enabled, internet_query_enabled]
+    ignore_changes = [internet_ingestion_access_type, internet_query_access_type]
   }
 }
 

--- a/modules/vnet-shared/network.tf
+++ b/modules/vnet-shared/network.tf
@@ -178,10 +178,9 @@ resource "azurerm_private_dns_zone" "key_vault" {
 }
 
 resource "azurerm_private_dns_zone_virtual_network_link" "key_vault" {
-  name                  = "link-${azurerm_private_dns_zone.key_vault.name}-${azurerm_virtual_network.this.name}"
-  resource_group_name   = var.resource_group_name
-  private_dns_zone_name = azurerm_private_dns_zone.key_vault.name
-  virtual_network_id    = azurerm_virtual_network.this.id
+  name                = "link-${azurerm_private_dns_zone.key_vault.name}-${azurerm_virtual_network.this.name}"
+  private_dns_zone_id = azurerm_private_dns_zone.key_vault.id
+  virtual_network_id  = azurerm_virtual_network.this.id
 }
 
 resource "azurerm_private_endpoint" "key_vault" {
@@ -218,10 +217,9 @@ resource "azurerm_private_dns_zone" "ampls" {
 resource "azurerm_private_dns_zone_virtual_network_link" "ampls" {
   for_each = azurerm_private_dns_zone.ampls
 
-  name                  = "link-${each.value.name}-${azurerm_virtual_network.this.name}"
-  resource_group_name   = var.resource_group_name
-  private_dns_zone_name = each.value.name
-  virtual_network_id    = azurerm_virtual_network.this.id
+  name                = "link-${each.value.name}-${azurerm_virtual_network.this.name}"
+  private_dns_zone_id = each.value.id
+  virtual_network_id  = azurerm_virtual_network.this.id
 }
 
 resource "azurerm_private_endpoint" "ampls" {

--- a/modules/vnet-shared/terraform.tf
+++ b/modules/vnet-shared/terraform.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 4.81.0"
+      version = "~> 5.0.1"
     }
 
     random = {

--- a/modules/vwan/terraform.tf
+++ b/modules/vwan/terraform.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 4.81.0"
+      version = "~> 5.0.1"
     }
 
     tls = {

--- a/terraform.tf
+++ b/terraform.tf
@@ -14,7 +14,7 @@ terraform {
 
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 4.81.0"
+      version = "~> 5.0.1"
     }
 
     cloudinit = {


### PR DESCRIPTION
## Summary

Migrates the **root sandbox configuration** and all root-reachable child modules (`modules/*` plus the `extras/modules/*` referenced by `main.tf`) from `azurerm ~> 4.81.0` to `~> 5.0.1`, including all code changes required by azurerm 5.0's breaking changes.

This supersedes the 11 Dependabot PRs for these paths (#574, #575, #576, #577, #578, #579, #580, #582, #584, #585, #586), which only raise the version constraint. On their own they fail `terraform validate` under 5.0 — the provider bump and the code fixes are coupled (new syntax is 5.0-only, old syntax is 4.x-only), so they must land together in one change.

## Breaking changes addressed

1. **`azurerm_private_dns_zone_virtual_network_link`** (#588) — the `resource_group_name` + `private_dns_zone_name` pair was removed; the required `private_dns_zone_id` is now used instead.
   - `modules/vnet-shared/network.tf` — `key_vault` and `ampls` links
   - `modules/vnet-app/network.tf` — the three `for_each` links
2. **`azurerm_log_analytics_workspace`** (#589) — the `internet_ingestion_enabled` / `internet_query_enabled` booleans were removed; replaced with `internet_ingestion_access_type` / `internet_query_access_type` (`"Enabled"`/`"Disabled"`), and the `ignore_changes` lifecycle updated to match.
   - `modules/vnet-shared/main.tf`
   - The root `azapi_update_resource` barrier is **unaffected** — it sets the raw ARM `publicNetworkAccessForIngestion` / `publicNetworkAccessForQuery` properties, not the provider arguments.

### Additional breaking changes discovered during migration (not previously tracked)

3. **`azurerm_monitor_diagnostic_setting`** — the `metric` block was removed in 5.0 (replaced by `enabled_metric`). The Key Vault "Audit Logs" setting in `modules/vnet-shared/main.tf` only enables audit logs (no metrics), so the now-invalid `lifecycle { ignore_changes = [metric] }` is simply removed.
4. **`azurerm_container_registry`** — the `trust_policy_enabled` argument was removed (ACR content trust retired). It was set to `false` (disabled) in `modules/vnet-app/main.tf`, so removing it preserves behavior.

## Validation

- `terraform init` resolves `azurerm v5.0.1`.
- `terraform validate` (all modules) → **Success! The configuration is valid.**
- `terraform fmt -recursive` → clean.
- `tflint` (recommended + azurerm ruleset), root and changed modules → **no findings**.

> ⚠️ This is a breaking **major** provider upgrade. It has not yet been deployment-tested (`terraform apply`) — recommend an apply against a sandbox before merge, as was done for the `rg-devops-iac` migration (#590).

## Related

- Addresses #588 and #589 for the root sandbox config.
- Supersedes Dependabot PRs #574, #575, #576, #577, #578, #579, #580, #582, #584, #585, #586 (can be closed once this merges).