### PR TITLE
Default VM OS disks to StandardSSD_LRS and reject Standard HDD (#593)

### DIFF
--- a/extras/configurations/rg-devops-iac/modules/vm-jumpbox-linux/README.md
+++ b/extras/configurations/rg-devops-iac/modules/vm-jumpbox-linux/README.md
@@ -25,6 +25,9 @@ This module implements a stand-alone Linux virtual machine for use as a jumpbox 
   * terraform
 * Pre-configured environment variables for using Azure Blob Storage as a Terraform state backend.
 
+> [!IMPORTANT]
+> **OS disk type change (Standard HDD retirement).** The default for `vm_jumpbox_linux_storage_account_type` is now `StandardSSD_LRS` and Standard HDD (`Standard_LRS`) is no longer permitted, because [Azure is retiring Standard HDD OS disks on September 8, 2028](https://learn.microsoft.com/en-us/azure/virtual-machines/disks-hdd-os-retirement). Fresh deployments are unaffected. For an **existing** deployment created with `Standard_LRS`, changing `os_disk.storage_account_type` forces Terraform to **replace the VM** (destroy and recreate), which causes downtime; the VM is re-provisioned by cloud-init, so the recommended path is to let Terraform recreate it during a maintenance window. To avoid replacement, deallocate the VM and change its OS disk SKU in place (Azure portal/CLI) *before* applying, then set the variable to the new SKU so Terraform detects no change.
+
 ## Smoke Testing
 
 This section describes how to test the module after deployment.
@@ -203,7 +206,7 @@ vm_jumpbox_linux_image_sku | `server` | The SKU of the virtual machine image use
 vm_jumpbox_linux_image_version | `Latest` | The version of the virtual machine image used to create the VM.
 vm_jumpbox_linux_name | jumplinux2 | The name of the VM.
 vm_jumpbox_linux_size | `Standard_B2ls_v2` | The size of the virtual machine.
-vm_jumpbox_linux_storage_account_type | `Standard_LRS` | The storage type to be used for the VM's OS and data disks.
+vm_jumpbox_linux_storage_account_type | `StandardSSD_LRS` | The storage type to be used for the VM's OS disk. Standard HDD (`Standard_LRS`) is not permitted because Azure is retiring Standard HDD OS disks on September 8, 2028.
 
 ### Module Resources
 

--- a/extras/configurations/rg-devops-iac/modules/vm-jumpbox-linux/variables.tf
+++ b/extras/configurations/rg-devops-iac/modules/vm-jumpbox-linux/variables.tf
@@ -160,11 +160,11 @@ variable "vm_jumpbox_linux_size" {
 
 variable "vm_jumpbox_linux_storage_account_type" {
   type        = string
-  description = "The storage type to be used for the VMs OS and data disks"
-  default     = "Standard_LRS"
+  description = "The storage type to be used for the VM's OS disk. Standard HDD (Standard_LRS) is not permitted because Azure is retiring Standard HDD OS disks on September 8, 2028."
+  default     = "StandardSSD_LRS"
 
   validation {
-    condition     = contains(["Standard_LRS", "Premium_LRS", "StandardSSD_LRS", "Premium_ZRS", "StandardSSD_ZRS"], var.vm_jumpbox_linux_storage_account_type)
-    error_message = "The 'vm_adds_storage_account_type' must be one of the valid Azure storage SKUs for managed disks: 'Standard_LRS', 'Premium_LRS', 'StandardSSD_LRS', 'Premium_ZRS', or 'StandardSSD_ZRS'."
+    condition     = contains(["Premium_LRS", "StandardSSD_LRS", "Premium_ZRS", "StandardSSD_ZRS"], var.vm_jumpbox_linux_storage_account_type)
+    error_message = "The 'vm_jumpbox_linux_storage_account_type' must be one of the valid Azure storage SKUs for OS disks: 'Premium_LRS', 'StandardSSD_LRS', 'Premium_ZRS', or 'StandardSSD_ZRS'. Standard HDD (Standard_LRS) is not permitted for OS disks."
   }
 }

--- a/modules/vm-jumpbox-linux/README.md
+++ b/modules/vm-jumpbox-linux/README.md
@@ -45,6 +45,9 @@ This configuration implements a Linux virtual machine for use as a jumpbox. The 
 
 The estimated provisioning time for this module is 3 minutes.
 
+> [!IMPORTANT]
+> **OS disk type change (Standard HDD retirement).** The default for `vm_jumpbox_linux_storage_account_type` is now `StandardSSD_LRS` and Standard HDD (`Standard_LRS`) is no longer permitted, because [Azure is retiring Standard HDD OS disks on September 8, 2028](https://learn.microsoft.com/en-us/azure/virtual-machines/disks-hdd-os-retirement). Fresh deployments are unaffected. For an **existing** deployment created with `Standard_LRS`, changing `os_disk.storage_account_type` forces Terraform to **replace the VM** (destroy and recreate), which causes downtime; the jumpbox is stateless and re-provisioned by cloud-init, so the recommended path is to let Terraform recreate it during a maintenance window. To avoid replacement, deallocate the VM and change its OS disk SKU in place (Azure portal/CLI) *before* applying, then set the variable to the new SKU so Terraform detects no change.
+
 ## Smoke Testing
 
 This section describes how to test the module after deployment.
@@ -232,7 +235,7 @@ vm_jumpbox_linux_image_sku | `server` | The SKU of the virtual machine image use
 vm_jumpbox_linux_image_version | `Latest` | The version of the virtual machine image used to create the VM.
 vm_jumpbox_linux_name | jumplinux1 | The name of the VM.
 vm_jumpbox_linux_size | `Standard_B2ls_v2` | The size of the virtual machine.
-vm_jumpbox_linux_storage_account_type | `Standard_LRS` | The storage type to be used for the VM's OS and data disks.
+vm_jumpbox_linux_storage_account_type | `StandardSSD_LRS` | The storage type to be used for the VM's OS disk. Standard HDD (`Standard_LRS`) is not permitted because Azure is retiring Standard HDD OS disks on September 8, 2028.
 
 ### Module Resources
 

--- a/modules/vm-jumpbox-linux/variables.tf
+++ b/modules/vm-jumpbox-linux/variables.tf
@@ -207,11 +207,11 @@ variable "vm_jumpbox_linux_size" {
 
 variable "vm_jumpbox_linux_storage_account_type" {
   type        = string
-  description = "The storage type to be used for the VMs OS and data disks"
-  default     = "Standard_LRS"
+  description = "The storage type to be used for the VM's OS disk. Standard HDD (Standard_LRS) is not permitted because Azure is retiring Standard HDD OS disks on September 8, 2028."
+  default     = "StandardSSD_LRS"
 
   validation {
-    condition     = contains(["Standard_LRS", "Premium_LRS", "StandardSSD_LRS", "Premium_ZRS", "StandardSSD_ZRS"], var.vm_jumpbox_linux_storage_account_type)
-    error_message = "The 'vm_adds_storage_account_type' must be one of the valid Azure storage SKUs for managed disks: 'Standard_LRS', 'Premium_LRS', 'StandardSSD_LRS', 'Premium_ZRS', or 'StandardSSD_ZRS'."
+    condition     = contains(["Premium_LRS", "StandardSSD_LRS", "Premium_ZRS", "StandardSSD_ZRS"], var.vm_jumpbox_linux_storage_account_type)
+    error_message = "The 'vm_jumpbox_linux_storage_account_type' must be one of the valid Azure storage SKUs for OS disks: 'Premium_LRS', 'StandardSSD_LRS', 'Premium_ZRS', or 'StandardSSD_ZRS'. Standard HDD (Standard_LRS) is not permitted for OS disks."
   }
 }

--- a/modules/vnet-app/README.md
+++ b/modules/vnet-app/README.md
@@ -31,6 +31,9 @@ This configuration implements a virtual network for applications including:
 
 The estimated provisioning time for this module is 31 minutes.
 
+> [!IMPORTANT]
+> **OS disk type change (Standard HDD retirement).** The default for `vm_jumpbox_win_storage_account_type` is now `StandardSSD_LRS` and Standard HDD (`Standard_LRS`) is no longer permitted, because [Azure is retiring Standard HDD OS disks on September 8, 2028](https://learn.microsoft.com/en-us/azure/virtual-machines/disks-hdd-os-retirement). Fresh deployments are unaffected. For an **existing** deployment created with `Standard_LRS`, changing `os_disk.storage_account_type` forces Terraform to **replace the VM** (destroy and recreate), which causes downtime; the Windows jumpbox is domain-joined and re-provisioned by its run-command configuration, so the recommended path is to let Terraform recreate it during a maintenance window. To avoid replacement, deallocate the VM and change its OS disk SKU in place (Azure portal/CLI) *before* applying, then set the variable to the new SKU so Terraform detects no change.
+
 ## Smoke testing
 
 The steps in this section verify that the Windows jumpbox VM (jumpwin1) is configured correctly.
@@ -162,7 +165,7 @@ vm_jumpbox_win_image_sku | `2025-datacenter-azure-edition` | The SKU for the vir
 vm_jumpbox_win_image_version | `Latest` | The version of the virtual machine image used to create the VM.
 vm_jumpbox_win_name | jumpwin1 | The name of the VM.
 vm_jumpbox_win_size | `Standard_B2ls_v2` | The size of the VM.
-vm_jumpbox_win_storage_account_type | `Standard_LRS` | The storage account type used for the managed disks attached to the VM.
+vm_jumpbox_win_storage_account_type | `StandardSSD_LRS` | The storage type to be used for the VM's OS disk. Standard HDD (`Standard_LRS`) is not permitted because Azure is retiring Standard HDD OS disks on September 8, 2028.
 vnet_address_space | 10.2.0.0/16 | The address space for the application virtual network.
 vnet_name | app | The name of the application virtual network.
 

--- a/modules/vnet-app/variables.tf
+++ b/modules/vnet-app/variables.tf
@@ -398,12 +398,12 @@ variable "vm_jumpbox_win_size" {
 
 variable "vm_jumpbox_win_storage_account_type" {
   type        = string
-  description = "The storage type to be used for the VMs OS and data disks."
-  default     = "Standard_LRS"
+  description = "The storage type to be used for the VM's OS disk. Standard HDD (Standard_LRS) is not permitted because Azure is retiring Standard HDD OS disks on September 8, 2028."
+  default     = "StandardSSD_LRS"
 
   validation {
-    condition     = contains(["Standard_LRS", "Premium_LRS", "StandardSSD_LRS", "Premium_ZRS", "StandardSSD_ZRS"], var.vm_jumpbox_win_storage_account_type)
-    error_message = "Must be one of the valid Azure storage SKUs for managed disks: 'Standard_LRS', 'Premium_LRS', 'StandardSSD_LRS', 'Premium_ZRS', or 'StandardSSD_ZRS'."
+    condition     = contains(["Premium_LRS", "StandardSSD_LRS", "Premium_ZRS", "StandardSSD_ZRS"], var.vm_jumpbox_win_storage_account_type)
+    error_message = "The 'vm_jumpbox_win_storage_account_type' must be one of the valid Azure storage SKUs for OS disks: 'Premium_LRS', 'StandardSSD_LRS', 'Premium_ZRS', or 'StandardSSD_ZRS'. Standard HDD (Standard_LRS) is not permitted for OS disks."
   }
 }
 

--- a/modules/vnet-shared/README.md
+++ b/modules/vnet-shared/README.md
@@ -24,6 +24,9 @@ This module implements a virtual network with shared services used by all the co
 
 The estimated provisioning time for this module is 23 minutes.
 
+> [!IMPORTANT]
+> **OS disk type change (Standard HDD retirement).** The default for `vm_adds_storage_account_type` is now `StandardSSD_LRS` and Standard HDD (`Standard_LRS`) is no longer permitted, because [Azure is retiring Standard HDD OS disks on September 8, 2028](https://learn.microsoft.com/en-us/azure/virtual-machines/disks-hdd-os-retirement). Fresh deployments are unaffected. For an **existing** deployment created with `Standard_LRS`, changing `os_disk.storage_account_type` forces Terraform to **replace the VM** (destroy and recreate). This VM is the Active Directory domain controller and DNS server that other modules depend on, so its replacement causes an AD/DNS outage that will disrupt domain-joined VMs and dependent modules until it re-provisions. To avoid replacement and downtime, deallocate the VM and change its OS disk SKU in place (Azure portal/CLI) *before* applying, then set the variable to the new SKU so Terraform detects no change. If you allow a replacement instead, schedule a maintenance window and expect dependent VMs to require domain re-join/re-provisioning.
+
 ## Smoke testing
 
 * Explore your newly provisioned resources in the Azure portal:
@@ -104,7 +107,7 @@ vm_adds_image_sku | 2025-datacenter-azure-edition-core | The SKU of the virtual 
 vm_adds_image_version | Latest | The version of the virtual machine image used to create the VM.
 vm_adds_name | adds1 | The name of the VM.
 vm_adds_size | Standard_B2ls_v2 | The size of the virtual machine.
-vm_adds_storage_account_type | Standard_LRS | The storage type to be used for the VM's managed disks.
+vm_adds_storage_account_type | `StandardSSD_LRS` | The storage type to be used for the VM's OS disk. Standard HDD (`Standard_LRS`) is not permitted because Azure is retiring Standard HDD OS disks on September 8, 2028.
 vnet_address_space | 10.1.0.0/16 | The address range for the virtual network.
 vnet_name | shared | The name of the new virtual network.
 

--- a/modules/vnet-shared/variables.tf
+++ b/modules/vnet-shared/variables.tf
@@ -263,12 +263,12 @@ variable "vm_adds_size" {
 
 variable "vm_adds_storage_account_type" {
   type        = string
-  description = "The storage type to be used for the VM's managed disks."
-  default     = "Standard_LRS"
+  description = "The storage type to be used for the VM's OS disk. Standard HDD (Standard_LRS) is not permitted because Azure is retiring Standard HDD OS disks on September 8, 2028."
+  default     = "StandardSSD_LRS"
 
   validation {
-    condition     = contains(["Standard_LRS", "Premium_LRS", "StandardSSD_LRS", "Premium_ZRS", "StandardSSD_ZRS"], var.vm_adds_storage_account_type)
-    error_message = "Must be one of the valid Azure storage SKUs for managed disks: 'Standard_LRS', 'Premium_LRS', 'StandardSSD_LRS', 'Premium_ZRS', or 'StandardSSD_ZRS'."
+    condition     = contains(["Premium_LRS", "StandardSSD_LRS", "Premium_ZRS", "StandardSSD_ZRS"], var.vm_adds_storage_account_type)
+    error_message = "The 'vm_adds_storage_account_type' must be one of the valid Azure storage SKUs for OS disks: 'Premium_LRS', 'StandardSSD_LRS', 'Premium_ZRS', or 'StandardSSD_ZRS'. Standard HDD (Standard_LRS) is not permitted for OS disks."
   }
 }
 


### PR DESCRIPTION
## Summary

Azure will retire Standard HDD OS disks on September 8, 2028 ([retirement notice](https://learn.microsoft.com/en-us/azure/virtual-machines/disks-hdd-os-retirement)). This PR stops all affected sandbox VMs from defaulting their OS disks to Standard HDD and prevents new Standard HDD OS disks from being created.

Fixes #593 (which also absorbed the closed #592 rg-devops-iac scope).

## Changes

For each affected OS disk variable — Linux jumpbox (`modules/vm-jumpbox-linux`), Windows jumpbox (`modules/vnet-app`), domain controller (`modules/vnet-shared`), and the standalone `extras/configurations/rg-devops-iac` Linux VM:

- Change the default from `Standard_LRS` to `StandardSSD_LRS`.
- Remove `Standard_LRS` from the validation allow-list so the modules reject Standard HDD, keeping only OS-disk-valid SSD SKUs (`StandardSSD_LRS`, `Premium_LRS`, `StandardSSD_ZRS`, `Premium_ZRS`).
- Clarify variable descriptions to refer to the **OS disk** (previously "OS and data disks" / "managed disks").
- Correct copy-pasted/inaccurate validation error messages.
- Update each affected module README's variable table and add OS disk migration guidance covering VM replacement/downtime, the domain controller dependency implications, and an in-place SKU-change path to avoid Terraform replacement.

## Acceptance criteria

- [x] A fresh sandbox deployment provisions no Standard HDD OS disks (defaults are `StandardSSD_LRS`).
- [x] A fresh `rg-devops-iac` deployment provisions no Standard HDD OS disk.
- [x] Terraform validation rejects `Standard_LRS` for each affected OS disk variable.
- [x] Existing deployments have migration guidance addressing downtime, dependencies, and Terraform lifecycle implications.
- [x] `terraform validate` passes for both the root module and the `rg-devops-iac` configuration; `terraform fmt` is clean.

## Testing

- `terraform validate` — root module: **Success**
- `terraform validate` — `extras/configurations/rg-devops-iac`: **Success**
- `terraform fmt -check -recursive` — clean

No `terraform apply` was run (out of scope for these default/validation/doc changes).