### PR TITLE
bootstrap: default arm_client_id prompt to TF_VAR_arm_client_id env var

### DIFF
--- a/extras/configurations/rg-devops-iac/scripts/bootstrap.ps1
+++ b/extras/configurations/rg-devops-iac/scripts/bootstrap.ps1
@@ -96,8 +96,16 @@ $defaultUserObjectId = (Show-JWTtoken -token (Get-AzAccessToken -AsSecureString)
 # Set default Microsoft Entra tenant id from currently logged in Azure PowerShell session
 $defaultAadTenantId = (Get-AzContext).Tenant.Id
 
+# Set default service principal appId from TF_VAR_arm_client_id environment variable
+$defaultArmClientId = $env:TF_VAR_arm_client_id
+
 # Get user input
-$armClientId = Read-Host "Service principal appId (arm_client_id)"
+$armClientId = Read-Host "Service principal appId (arm_client_id) default '$defaultArmClientId'"
+
+if (-not $armClientId) {
+    $armClientId = $defaultArmClientId
+}
+
 $aadTenantId = Read-Host "Microsoft Entra tenant id (aad_tenant_id) default '$defaultAadTenantId'"
 
 if (-not $aadTenantId) {

--- a/extras/configurations/rg-devops-iac/scripts/bootstrap.sh
+++ b/extras/configurations/rg-devops-iac/scripts/bootstrap.sh
@@ -68,6 +68,7 @@ default_user_object_id=$(az account get-access-token --query accessToken --outpu
 default_aad_tenant_id=$(az account show --query tenantId --output tsv)
 
 # Get user input
+# shellcheck disable=SC2154  # TF_VAR_arm_client_id is an external Terraform env var, optionally exported by the caller.
 read -e -i "$TF_VAR_arm_client_id"  -p "Service principal appId (arm_client_id) -----------------: " arm_client_id
 read -e -i $default_aad_tenant_id   -p "Microsoft Entra tenant id (aad_tenant_id) ---------------: " aad_tenant_id
 read -e -i $default_user_object_id  -p "Object id for Azure CLI signed in user (user_object_id) -: " user_object_id

--- a/extras/configurations/rg-devops-iac/scripts/bootstrap.sh
+++ b/extras/configurations/rg-devops-iac/scripts/bootstrap.sh
@@ -68,7 +68,7 @@ default_user_object_id=$(az account get-access-token --query accessToken --outpu
 default_aad_tenant_id=$(az account show --query tenantId --output tsv)
 
 # Get user input
-read -e                             -p "Service principal appId (arm_client_id) -----------------: " arm_client_id
+read -e -i "$TF_VAR_arm_client_id"  -p "Service principal appId (arm_client_id) -----------------: " arm_client_id
 read -e -i $default_aad_tenant_id   -p "Microsoft Entra tenant id (aad_tenant_id) ---------------: " aad_tenant_id
 read -e -i $default_user_object_id  -p "Object id for Azure CLI signed in user (user_object_id) -: " user_object_id
 read -e -i $default_subscription_id -p "Azure subscription id (subscription_id) -----------------: " subscription_id

--- a/scripts/bootstrap.ps1
+++ b/scripts/bootstrap.ps1
@@ -98,8 +98,16 @@ $defaultUserName = (Get-AzADUser -ObjectId $defaultUserObjectId).UserPrincipalNa
 # Set default Microsoft Entra tenant id from currently logged in Azure PowerShell session
 $defaultAadTenantId = (Get-AzContext).Tenant.Id
 
+# Set default service principal appId from TF_VAR_arm_client_id environment variable
+$defaultArmClientId = $env:TF_VAR_arm_client_id
+
 # Get user input
-$armClientId = Read-Host "Service principal appId (arm_client_id)"
+$armClientId = Read-Host "Service principal appId (arm_client_id) default '$defaultArmClientId'"
+
+if (-not $armClientId) {
+    $armClientId = $defaultArmClientId
+}
+
 $aadTenantId = Read-Host "Microsoft Entra tenant id (aad_tenant_id) default '$defaultAadTenantId'"
 
 if (-not $aadTenantId) {

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -72,7 +72,7 @@ default_user_name=$(az ad user show --id $default_user_object_id --query userPri
 default_aad_tenant_id=$(az account show --query tenantId --output tsv)
 
 # Get user input
-read -e                             -p "Service principal appId (arm_client_id) -----------------: " arm_client_id
+read -e -i "$TF_VAR_arm_client_id"  -p "Service principal appId (arm_client_id) -----------------: " arm_client_id
 read -e -i $default_aad_tenant_id   -p "Microsoft Entra tenant id (aad_tenant_id) ---------------: " aad_tenant_id
 read -e -i $default_user_name       -p "User name for Azure CLI signed in user (user_name) ------: " user_name
 read -e -i $default_user_object_id  -p "Object id for Azure CLI signed in user (user_object_id) -: " user_object_id

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -72,6 +72,7 @@ default_user_name=$(az ad user show --id $default_user_object_id --query userPri
 default_aad_tenant_id=$(az account show --query tenantId --output tsv)
 
 # Get user input
+# shellcheck disable=SC2154  # TF_VAR_arm_client_id is an external Terraform env var, optionally exported by the caller.
 read -e -i "$TF_VAR_arm_client_id"  -p "Service principal appId (arm_client_id) -----------------: " arm_client_id
 read -e -i $default_aad_tenant_id   -p "Microsoft Entra tenant id (aad_tenant_id) ---------------: " aad_tenant_id
 read -e -i $default_user_name       -p "User name for Azure CLI signed in user (user_name) ------: " user_name


### PR DESCRIPTION
Fixes #599.

## Summary

Prefill the bootstrap `arm_client_id` prompt from the `TF_VAR_arm_client_id` environment variable so it flows through deterministically (and is still validated against Azure). Previously the appId prompt had no default and never consulted the env var, so a value exported alongside `TF_VAR_arm_client_secret` was inert — and because bootstrap always writes an `arm_client_id = "..."` line to `terraform.tfvars`, that tfvars entry silently out-ranked the env var (Terraform precedence: `*.tfvars` > `TF_VAR_*`). Falls back to empty when unset, so the change is non-breaking; the existing `arm_client_id is required` validation still applies.

Applied to **all four bootstrap variants**:

- `scripts/bootstrap.sh`
- `scripts/bootstrap.ps1`
- `extras/configurations/rg-devops-iac/scripts/bootstrap.sh`
- `extras/configurations/rg-devops-iac/scripts/bootstrap.ps1`

## Changes

- **Bash**: `read -e -i "$TF_VAR_arm_client_id" -p ...`, mirroring the existing `-i "$default_*"` pattern used for the other prompts.
- **PowerShell**: `Read-Host` has no `-i`, so set `$defaultArmClientId = $env:TF_VAR_arm_client_id` and apply the same default-fallback pattern already used for `aad_tenant_id`, `user_name`, etc.

## Testing

- `bash -n` passes for both `.sh` scripts.
- `[ScriptBlock]::Create(...)` parse check passes for both `.ps1` scripts.