### PR TITLE
Provision dynamic swapfile in both vm-jumpbox-linux cloud-init configs (#595)

### DIFF
--- a/extras/configurations/rg-devops-iac/modules/vm-jumpbox-linux/README.md
+++ b/extras/configurations/rg-devops-iac/modules/vm-jumpbox-linux/README.md
@@ -16,7 +16,7 @@
 This module implements a stand-alone Linux virtual machine for use as a jumpbox or DevOps agent. The VM is configured using cloud-init and offers the following capabilities:
 
 * Secure SSH access using a private SSH key stored in Azure Key Vault.
-* Automatic swap provisioning sized to the VM's memory (see note below).
+* Automatic swapfile provisioning sized to the VM's physical memory (VMs with 8 GiB RAM or more get no swap; smaller VMs get enough swap to reach roughly 12 GiB of RAM plus swap total, with `vm.swappiness=10`).
 * Remote-ssh development capabilities using Visual Studio Code.
 * Pre-installed software packages, including:
   * azure-cli
@@ -25,11 +25,6 @@ This module implements a stand-alone Linux virtual machine for use as a jumpbox 
   * python3-pip
   * terraform
 * Pre-configured environment variables for using Azure Blob Storage as a Terraform state backend.
-
-> [!NOTE]
-> **Automatic swap provisioning.** cloud-init provisions a swapfile (`/swapfile`) sized dynamically from the VM's physical memory so that long, memory-intensive operations (such as a full `terraform apply` run on this Terraform execution host) have kernel reclaim headroom instead of thrashing page cache and dropping SSH — which previously left the VM unresponsive until reboot. The size scales with the VM SKU: VMs with **≥ 8 GiB RAM skip swap entirely** (they don't need it), while smaller VMs (e.g. the default `Standard_B2ls_v2` with 4 GiB) get enough swap to reach roughly **12 GiB of RAM + swap total** (~8–9 GiB). The swapfile is persisted in `/etc/fstab` and `vm.swappiness` is set to `10` so RAM stays preferred and swap acts as a pressure-relief safety net. The logic is idempotent and skips provisioning if swap is already active. For heavy multi-module deployments, also consider increasing `vm_jumpbox_linux_size` to a larger, non-burstable SKU.
-
-<!-- markdownlint separator between adjacent blockquotes -->
 
 > [!IMPORTANT]
 > **OS disk type change (Standard HDD retirement).** The default for `vm_jumpbox_linux_storage_account_type` is now `StandardSSD_LRS` and Standard HDD (`Standard_LRS`) is no longer permitted, because [Azure is retiring Standard HDD OS disks on September 8, 2028](https://learn.microsoft.com/en-us/azure/virtual-machines/disks-hdd-os-retirement). Fresh deployments are unaffected. For an **existing** deployment created with `Standard_LRS`, changing `os_disk.storage_account_type` forces Terraform to **replace the VM** (destroy and recreate), which causes downtime; the VM is re-provisioned by cloud-init, so the recommended path is to let Terraform recreate it during a maintenance window. To avoid replacement, deallocate the VM and change its OS disk SKU in place (Azure portal/CLI) *before* applying, then set the variable to the new SKU so Terraform detects no change.

--- a/extras/configurations/rg-devops-iac/modules/vm-jumpbox-linux/README.md
+++ b/extras/configurations/rg-devops-iac/modules/vm-jumpbox-linux/README.md
@@ -26,9 +26,6 @@ This module implements a stand-alone Linux virtual machine for use as a jumpbox 
   * terraform
 * Pre-configured environment variables for using Azure Blob Storage as a Terraform state backend.
 
-> [!IMPORTANT]
-> **OS disk type change (Standard HDD retirement).** The default for `vm_jumpbox_linux_storage_account_type` is now `StandardSSD_LRS` and Standard HDD (`Standard_LRS`) is no longer permitted, because [Azure is retiring Standard HDD OS disks on September 8, 2028](https://learn.microsoft.com/en-us/azure/virtual-machines/disks-hdd-os-retirement). Fresh deployments are unaffected. For an **existing** deployment created with `Standard_LRS`, changing `os_disk.storage_account_type` forces Terraform to **replace the VM** (destroy and recreate), which causes downtime; the VM is re-provisioned by cloud-init, so the recommended path is to let Terraform recreate it during a maintenance window. To avoid replacement, deallocate the VM and change its OS disk SKU in place (Azure portal/CLI) *before* applying, then set the variable to the new SKU so Terraform detects no change.
-
 ## Smoke Testing
 
 This section describes how to test the module after deployment.

--- a/extras/configurations/rg-devops-iac/modules/vm-jumpbox-linux/README.md
+++ b/extras/configurations/rg-devops-iac/modules/vm-jumpbox-linux/README.md
@@ -16,6 +16,7 @@
 This module implements a stand-alone Linux virtual machine for use as a jumpbox or DevOps agent. The VM is configured using cloud-init and offers the following capabilities:
 
 * Secure SSH access using a private SSH key stored in Azure Key Vault.
+* Automatic swap provisioning sized to the VM's memory (see note below).
 * Remote-ssh development capabilities using Visual Studio Code.
 * Pre-installed software packages, including:
   * azure-cli
@@ -24,6 +25,11 @@ This module implements a stand-alone Linux virtual machine for use as a jumpbox 
   * python3-pip
   * terraform
 * Pre-configured environment variables for using Azure Blob Storage as a Terraform state backend.
+
+> [!NOTE]
+> **Automatic swap provisioning.** cloud-init provisions a swapfile (`/swapfile`) sized dynamically from the VM's physical memory so that long, memory-intensive operations (such as a full `terraform apply` run on this Terraform execution host) have kernel reclaim headroom instead of thrashing page cache and dropping SSH — which previously left the VM unresponsive until reboot. The size scales with the VM SKU: VMs with **≥ 8 GiB RAM skip swap entirely** (they don't need it), while smaller VMs (e.g. the default `Standard_B2ls_v2` with 4 GiB) get enough swap to reach roughly **12 GiB of RAM + swap total** (~8–9 GiB). The swapfile is persisted in `/etc/fstab` and `vm.swappiness` is set to `10` so RAM stays preferred and swap acts as a pressure-relief safety net. The logic is idempotent and skips provisioning if swap is already active. For heavy multi-module deployments, also consider increasing `vm_jumpbox_linux_size` to a larger, non-burstable SKU.
+
+<!-- markdownlint separator between adjacent blockquotes -->
 
 > [!IMPORTANT]
 > **OS disk type change (Standard HDD retirement).** The default for `vm_jumpbox_linux_storage_account_type` is now `StandardSSD_LRS` and Standard HDD (`Standard_LRS`) is no longer permitted, because [Azure is retiring Standard HDD OS disks on September 8, 2028](https://learn.microsoft.com/en-us/azure/virtual-machines/disks-hdd-os-retirement). Fresh deployments are unaffected. For an **existing** deployment created with `Standard_LRS`, changing `os_disk.storage_account_type` forces Terraform to **replace the VM** (destroy and recreate), which causes downtime; the VM is re-provisioned by cloud-init, so the recommended path is to let Terraform recreate it during a maintenance window. To avoid replacement, deallocate the VM and change its OS disk SKU in place (Azure portal/CLI) *before* applying, then set the variable to the new SKU so Terraform detects no change.

--- a/extras/configurations/rg-devops-iac/modules/vm-jumpbox-linux/README.md
+++ b/extras/configurations/rg-devops-iac/modules/vm-jumpbox-linux/README.md
@@ -16,7 +16,7 @@
 This module implements a stand-alone Linux virtual machine for use as a jumpbox or DevOps agent. The VM is configured using cloud-init and offers the following capabilities:
 
 * Secure SSH access using a private SSH key stored in Azure Key Vault.
-* Automatic swapfile provisioning sized to the VM's physical memory (VMs with 8 GiB RAM or more get no swap; smaller VMs get enough swap to reach roughly 12 GiB of RAM plus swap total, with `vm.swappiness=10`).
+* Automatic swapfile provisioning sized to the VM's memory (larger VMs get no swap).
 * Remote-ssh development capabilities using Visual Studio Code.
 * Pre-installed software packages, including:
   * azure-cli

--- a/extras/configurations/rg-devops-iac/modules/vm-jumpbox-linux/scripts/configure-vm-jumpbox-linux.yaml
+++ b/extras/configurations/rg-devops-iac/modules/vm-jumpbox-linux/scripts/configure-vm-jumpbox-linux.yaml
@@ -5,6 +5,7 @@
 cloud_config_modules:
   - apt_configure
   - package_update_upgrade_install
+  - runcmd
 
 bootcmd:
   - test -d /etc/apt/keyrings || install -m 0755 -d /etc/apt/keyrings

--- a/extras/configurations/rg-devops-iac/modules/vm-jumpbox-linux/scripts/configure-vm-jumpbox-linux.yaml
+++ b/extras/configurations/rg-devops-iac/modules/vm-jumpbox-linux/scripts/configure-vm-jumpbox-linux.yaml
@@ -67,7 +67,7 @@ write_files:
       ram_mib=$(( $(awk '/^MemTotal/ {print $2}' /proc/meminfo) / 1024 ))
 
       if [ "$ram_mib" -ge "$skip_threshold_mib" ]; then
-        echo "physical RAM ${ram_mib} MiB >= ${skip_threshold_mib} MiB; no swapfile needed"
+        echo "physical RAM $${ram_mib} MiB >= $${skip_threshold_mib} MiB; no swapfile needed"
         exit 0
       fi
 
@@ -77,8 +77,8 @@ write_files:
         swap_mib=2048
       fi
 
-      echo "physical RAM ${ram_mib} MiB; creating ${swap_mib} MiB swapfile at ${swapfile}"
-      fallocate -l "${swap_mib}M" "$swapfile" || dd if=/dev/zero of="$swapfile" bs=1M count="$swap_mib"
+      echo "physical RAM $${ram_mib} MiB; creating $${swap_mib} MiB swapfile at $${swapfile}"
+      fallocate -l "$${swap_mib}M" "$swapfile" || dd if=/dev/zero of="$swapfile" bs=1M count="$swap_mib"
       chmod 600 "$swapfile"
       mkswap "$swapfile"
       swapon "$swapfile"

--- a/extras/configurations/rg-devops-iac/modules/vm-jumpbox-linux/scripts/configure-vm-jumpbox-linux.yaml
+++ b/extras/configurations/rg-devops-iac/modules/vm-jumpbox-linux/scripts/configure-vm-jumpbox-linux.yaml
@@ -44,3 +44,51 @@ write_files:
       ARM_USE_MSI=true
       ARM_TENANT_ID=${aad_tenant_id}
     append: true
+  - path: /usr/local/sbin/configure-swap.sh
+    permissions: '0755'
+    content: |
+      #!/bin/bash
+      # Provision a swapfile sized dynamically from physical RAM to give the kernel
+      # reclaim headroom during long-running, memory-intensive operations (e.g. a full
+      # terraform apply) instead of thrashing page cache and dropping SSH. Swap size
+      # scales with VM size: larger VMs (>= ~8 GiB RAM) skip swap entirely, smaller VMs
+      # get enough swap to reach ~12 GiB of RAM + swap total. Idempotent and boot-safe.
+      set -euo pipefail
+
+      swapfile=/swapfile
+      target_total_mib=12288   # target RAM + swap headroom (~12 GiB)
+      skip_threshold_mib=7000  # skip swap when physical RAM >= ~8 GiB
+
+      if [ -n "$(swapon --show --noheadings)" ]; then
+        echo "swap already active; skipping swapfile provisioning"
+        exit 0
+      fi
+
+      ram_mib=$(( $(awk '/^MemTotal/ {print $2}' /proc/meminfo) / 1024 ))
+
+      if [ "$ram_mib" -ge "$skip_threshold_mib" ]; then
+        echo "physical RAM ${ram_mib} MiB >= ${skip_threshold_mib} MiB; no swapfile needed"
+        exit 0
+      fi
+
+      swap_mib=$(( target_total_mib - ram_mib ))
+      swap_mib=$(( ( (swap_mib + 1023) / 1024 ) * 1024 ))  # round up to whole GiB
+      if [ "$swap_mib" -lt 2048 ]; then
+        swap_mib=2048
+      fi
+
+      echo "physical RAM ${ram_mib} MiB; creating ${swap_mib} MiB swapfile at ${swapfile}"
+      fallocate -l "${swap_mib}M" "$swapfile" || dd if=/dev/zero of="$swapfile" bs=1M count="$swap_mib"
+      chmod 600 "$swapfile"
+      mkswap "$swapfile"
+      swapon "$swapfile"
+
+      if ! grep -q '^/swapfile ' /etc/fstab; then
+        echo "$swapfile none swap sw 0 0" >> /etc/fstab
+      fi
+
+      echo 'vm.swappiness=10' > /etc/sysctl.d/99-swappiness.conf
+      sysctl -w vm.swappiness=10
+
+runcmd:
+  - /usr/local/sbin/configure-swap.sh

--- a/modules/vm-jumpbox-linux/README.md
+++ b/modules/vm-jumpbox-linux/README.md
@@ -16,7 +16,7 @@
 This configuration implements a Linux virtual machine for use as a jumpbox. The VM is configured using cloud-init and offers the following capabilities:
 
 * Secure SSH access via Bastion using a private SSH key stored in Azure Key Vault.
-* Automatic swap provisioning sized to the VM's memory (see note below).
+* Automatic swapfile provisioning sized to the VM's physical memory (VMs with 8 GiB RAM or more get no swap; smaller VMs get enough swap to reach roughly 12 GiB of RAM plus swap total, with `vm.swappiness=10`).
 * Domain joined to the *mysandbox.local* Active Directory domain using winbind.
 * Remote-ssh development capabilities using Visual Studio Code on *jumpwin1*.
 * Secure AD integrated access to Azure Files SMB/cifs share automatically mounted by the VM.
@@ -45,11 +45,6 @@ This configuration implements a Linux virtual machine for use as a jumpbox. The 
   * winbind
 
 The estimated provisioning time for this module is 3 minutes.
-
-> [!NOTE]
-> **Automatic swap provisioning.** cloud-init provisions a swapfile (`/swapfile`) sized dynamically from the VM's physical memory so that long, memory-intensive operations (such as a full `terraform apply`) have kernel reclaim headroom instead of thrashing page cache and dropping SSH. The size scales with the VM SKU: VMs with **≥ 8 GiB RAM skip swap entirely** (they don't need it), while smaller VMs (e.g. the default `Standard_B2ls_v2` with 4 GiB) get enough swap to reach roughly **12 GiB of RAM + swap total** (~8–9 GiB). The swapfile is persisted in `/etc/fstab` and `vm.swappiness` is set to `10` so RAM stays preferred and swap acts as a pressure-relief safety net. The logic is idempotent and skips provisioning if swap is already active.
-
-<!-- markdownlint separator between adjacent blockquotes -->
 
 > [!IMPORTANT]
 > **OS disk type change (Standard HDD retirement).** The default for `vm_jumpbox_linux_storage_account_type` is now `StandardSSD_LRS` and Standard HDD (`Standard_LRS`) is no longer permitted, because [Azure is retiring Standard HDD OS disks on September 8, 2028](https://learn.microsoft.com/en-us/azure/virtual-machines/disks-hdd-os-retirement). Fresh deployments are unaffected. For an **existing** deployment created with `Standard_LRS`, changing `os_disk.storage_account_type` forces Terraform to **replace the VM** (destroy and recreate), which causes downtime; the jumpbox is stateless and re-provisioned by cloud-init, so the recommended path is to let Terraform recreate it during a maintenance window. To avoid replacement, deallocate the VM and change its OS disk SKU in place (Azure portal/CLI) *before* applying, then set the variable to the new SKU so Terraform detects no change.

--- a/modules/vm-jumpbox-linux/README.md
+++ b/modules/vm-jumpbox-linux/README.md
@@ -46,9 +46,6 @@ This configuration implements a Linux virtual machine for use as a jumpbox. The 
 
 The estimated provisioning time for this module is 3 minutes.
 
-> [!IMPORTANT]
-> **OS disk type change (Standard HDD retirement).** The default for `vm_jumpbox_linux_storage_account_type` is now `StandardSSD_LRS` and Standard HDD (`Standard_LRS`) is no longer permitted, because [Azure is retiring Standard HDD OS disks on September 8, 2028](https://learn.microsoft.com/en-us/azure/virtual-machines/disks-hdd-os-retirement). Fresh deployments are unaffected. For an **existing** deployment created with `Standard_LRS`, changing `os_disk.storage_account_type` forces Terraform to **replace the VM** (destroy and recreate), which causes downtime; the jumpbox is stateless and re-provisioned by cloud-init, so the recommended path is to let Terraform recreate it during a maintenance window. To avoid replacement, deallocate the VM and change its OS disk SKU in place (Azure portal/CLI) *before* applying, then set the variable to the new SKU so Terraform detects no change.
-
 ## Smoke Testing
 
 This section describes how to test the module after deployment.

--- a/modules/vm-jumpbox-linux/README.md
+++ b/modules/vm-jumpbox-linux/README.md
@@ -16,6 +16,7 @@
 This configuration implements a Linux virtual machine for use as a jumpbox. The VM is configured using cloud-init and offers the following capabilities:
 
 * Secure SSH access via Bastion using a private SSH key stored in Azure Key Vault.
+* Automatic swap provisioning sized to the VM's memory (see note below).
 * Domain joined to the *mysandbox.local* Active Directory domain using winbind.
 * Remote-ssh development capabilities using Visual Studio Code on *jumpwin1*.
 * Secure AD integrated access to Azure Files SMB/cifs share automatically mounted by the VM.
@@ -44,6 +45,11 @@ This configuration implements a Linux virtual machine for use as a jumpbox. The 
   * winbind
 
 The estimated provisioning time for this module is 3 minutes.
+
+> [!NOTE]
+> **Automatic swap provisioning.** cloud-init provisions a swapfile (`/swapfile`) sized dynamically from the VM's physical memory so that long, memory-intensive operations (such as a full `terraform apply`) have kernel reclaim headroom instead of thrashing page cache and dropping SSH. The size scales with the VM SKU: VMs with **≥ 8 GiB RAM skip swap entirely** (they don't need it), while smaller VMs (e.g. the default `Standard_B2ls_v2` with 4 GiB) get enough swap to reach roughly **12 GiB of RAM + swap total** (~8–9 GiB). The swapfile is persisted in `/etc/fstab` and `vm.swappiness` is set to `10` so RAM stays preferred and swap acts as a pressure-relief safety net. The logic is idempotent and skips provisioning if swap is already active.
+
+<!-- markdownlint separator between adjacent blockquotes -->
 
 > [!IMPORTANT]
 > **OS disk type change (Standard HDD retirement).** The default for `vm_jumpbox_linux_storage_account_type` is now `StandardSSD_LRS` and Standard HDD (`Standard_LRS`) is no longer permitted, because [Azure is retiring Standard HDD OS disks on September 8, 2028](https://learn.microsoft.com/en-us/azure/virtual-machines/disks-hdd-os-retirement). Fresh deployments are unaffected. For an **existing** deployment created with `Standard_LRS`, changing `os_disk.storage_account_type` forces Terraform to **replace the VM** (destroy and recreate), which causes downtime; the jumpbox is stateless and re-provisioned by cloud-init, so the recommended path is to let Terraform recreate it during a maintenance window. To avoid replacement, deallocate the VM and change its OS disk SKU in place (Azure portal/CLI) *before* applying, then set the variable to the new SKU so Terraform detects no change.

--- a/modules/vm-jumpbox-linux/README.md
+++ b/modules/vm-jumpbox-linux/README.md
@@ -16,7 +16,7 @@
 This configuration implements a Linux virtual machine for use as a jumpbox. The VM is configured using cloud-init and offers the following capabilities:
 
 * Secure SSH access via Bastion using a private SSH key stored in Azure Key Vault.
-* Automatic swapfile provisioning sized to the VM's physical memory (VMs with 8 GiB RAM or more get no swap; smaller VMs get enough swap to reach roughly 12 GiB of RAM plus swap total, with `vm.swappiness=10`).
+* Automatic swapfile provisioning sized to the VM's memory (larger VMs get no swap).
 * Domain joined to the *mysandbox.local* Active Directory domain using winbind.
 * Remote-ssh development capabilities using Visual Studio Code on *jumpwin1*.
 * Secure AD integrated access to Azure Files SMB/cifs share automatically mounted by the VM.

--- a/modules/vm-jumpbox-linux/scripts/configure-vm-jumpbox-linux.yaml
+++ b/modules/vm-jumpbox-linux/scripts/configure-vm-jumpbox-linux.yaml
@@ -5,6 +5,7 @@
 cloud_config_modules:
   - apt_configure
   - package_update_upgrade_install
+  - runcmd
 
 bootcmd:
   - test -d /etc/apt/keyrings || install -m 0755 -d /etc/apt/keyrings

--- a/modules/vm-jumpbox-linux/scripts/configure-vm-jumpbox-linux.yaml
+++ b/modules/vm-jumpbox-linux/scripts/configure-vm-jumpbox-linux.yaml
@@ -86,7 +86,7 @@ write_files:
       ram_mib=$(( $(awk '/^MemTotal/ {print $2}' /proc/meminfo) / 1024 ))
 
       if [ "$ram_mib" -ge "$skip_threshold_mib" ]; then
-        echo "physical RAM ${ram_mib} MiB >= ${skip_threshold_mib} MiB; no swapfile needed"
+        echo "physical RAM $${ram_mib} MiB >= $${skip_threshold_mib} MiB; no swapfile needed"
         exit 0
       fi
 
@@ -96,8 +96,8 @@ write_files:
         swap_mib=2048
       fi
 
-      echo "physical RAM ${ram_mib} MiB; creating ${swap_mib} MiB swapfile at ${swapfile}"
-      fallocate -l "${swap_mib}M" "$swapfile" || dd if=/dev/zero of="$swapfile" bs=1M count="$swap_mib"
+      echo "physical RAM $${ram_mib} MiB; creating $${swap_mib} MiB swapfile at $${swapfile}"
+      fallocate -l "$${swap_mib}M" "$swapfile" || dd if=/dev/zero of="$swapfile" bs=1M count="$swap_mib"
       chmod 600 "$swapfile"
       mkswap "$swapfile"
       swapon "$swapfile"

--- a/modules/vm-jumpbox-linux/scripts/configure-vm-jumpbox-linux.yaml
+++ b/modules/vm-jumpbox-linux/scripts/configure-vm-jumpbox-linux.yaml
@@ -66,6 +66,51 @@ write_files:
       network: {config: disabled}
     path: /etc/cloud/cloud.cfg.d/99-disable-network-config.cfg
   - content: |
+      #!/bin/bash
+      # Provision a swapfile sized dynamically from physical RAM to give the kernel
+      # reclaim headroom during long-running, memory-intensive operations (e.g. a full
+      # terraform apply) instead of thrashing page cache and dropping SSH. Swap size
+      # scales with VM size: larger VMs (>= ~8 GiB RAM) skip swap entirely, smaller VMs
+      # get enough swap to reach ~12 GiB of RAM + swap total. Idempotent and boot-safe.
+      set -euo pipefail
+
+      swapfile=/swapfile
+      target_total_mib=12288   # target RAM + swap headroom (~12 GiB)
+      skip_threshold_mib=7000  # skip swap when physical RAM >= ~8 GiB
+
+      if [ -n "$(swapon --show --noheadings)" ]; then
+        echo "swap already active; skipping swapfile provisioning"
+        exit 0
+      fi
+
+      ram_mib=$(( $(awk '/^MemTotal/ {print $2}' /proc/meminfo) / 1024 ))
+
+      if [ "$ram_mib" -ge "$skip_threshold_mib" ]; then
+        echo "physical RAM ${ram_mib} MiB >= ${skip_threshold_mib} MiB; no swapfile needed"
+        exit 0
+      fi
+
+      swap_mib=$(( target_total_mib - ram_mib ))
+      swap_mib=$(( ( (swap_mib + 1023) / 1024 ) * 1024 ))  # round up to whole GiB
+      if [ "$swap_mib" -lt 2048 ]; then
+        swap_mib=2048
+      fi
+
+      echo "physical RAM ${ram_mib} MiB; creating ${swap_mib} MiB swapfile at ${swapfile}"
+      fallocate -l "${swap_mib}M" "$swapfile" || dd if=/dev/zero of="$swapfile" bs=1M count="$swap_mib"
+      chmod 600 "$swapfile"
+      mkswap "$swapfile"
+      swapon "$swapfile"
+
+      if ! grep -q '^/swapfile ' /etc/fstab; then
+        echo "$swapfile none swap sw 0 0" >> /etc/fstab
+      fi
+
+      echo 'vm.swappiness=10' > /etc/sysctl.d/99-swappiness.conf
+      sysctl -w vm.swappiness=10
+    path: /usr/local/sbin/configure-swap.sh
+    permissions: '0755'
+  - content: |
       {
         "adds_domain_name": "${adds_domain_name}",
         "dns_server": "${dns_server}",
@@ -75,3 +120,6 @@ write_files:
       }
     path: /etc/azuresandbox-conf.json
     permissions: '0644'
+
+runcmd:
+  - /usr/local/sbin/configure-swap.sh


### PR DESCRIPTION
Fixes #595.

## Problem

Both Linux jumpbox modules default to `Standard_B2ls_v2` (2 vCPU, **4 GiB RAM**, burstable) with **no swap**. On the Terraform execution host (`jumplinux2`), running a full sandbox `terraform apply` exhausts RAM, and with no swap the kernel repeatedly evicts and re-faults page cache (including `sshd`) instead of cleanly OOM-killing a process — the VM thrashes, `sshd` stops responding, Remote-SSH cannot reconnect, and recovery requires a reboot. The sandbox jumpbox (`jumplinux1`) shares the same latent misconfiguration.

## Fix

Bake an idempotent, boot-safe swapfile provisioner into **both** modules' cloud-init cloud-config (`scripts/configure-vm-jumpbox-linux.yaml`), written to `/usr/local/sbin/configure-swap.sh` and invoked from `runcmd`.

**Swap size scales with the VM SKU** (per the requirement that larger VMs may not need swap):

- Detects physical RAM at boot from `/proc/meminfo`.
- VMs with **≥ ~8 GiB RAM skip swap entirely**.
- Smaller VMs (e.g. the default 4 GiB `Standard_B2ls_v2`) get a swapfile sized to reach **~12 GiB of RAM + swap total** (~8–9 GiB), matching the fix validated end-to-end in the issue.
- Persists the swapfile in `/etc/fstab` and sets `vm.swappiness=10` (RAM preferred, swap as pressure-relief).
- Idempotent: no-op if swap is already active; falls back to `dd` if `fallocate` is unavailable.

| Physical RAM (MemTotal) | Result |
|---|---|
| ~3.8 GiB (4 GiB SKU) | ~9 GiB swap (~13 GiB total) |
| ~7.6 GiB (8 GiB SKU) | no swap |
| ~15.9 GiB (16 GiB SKU) | no swap |

## Files changed

- `modules/vm-jumpbox-linux/scripts/configure-vm-jumpbox-linux.yaml`
- `extras/configurations/rg-devops-iac/modules/vm-jumpbox-linux/scripts/configure-vm-jumpbox-linux.yaml`
- Both module `README.md` files (documented the behavior).

## Validation

- Both cloud-config YAMLs parse cleanly.
- Embedded script is ShellCheck-clean; sizing logic tested for 4/8/16 GiB.
- Local CI checks (`markdown`, `links`) pass.