### PR TITLE
Docs: highlight Azure Container Apps Sandboxes callout in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Azure Sandbox is not intended for production use but serves as a powerful tool f
 > [!TIP]
 > **Looking for a different sandbox solution?**
 >
-> [**Azure Container Apps Sandboxes**](https://sandboxes.azure.com/) delivers production-grade isolation as a native Azure service — with default-deny egress control, sub-second provisioning, snapshots and more. [**Learn more →**](https://sandboxes.azure.com/)
+> [**Azure Container Apps Sandboxes**](https://sandboxes.azure.com/) delivers production-grade isolation as a native Azure service — with default-deny egress control, sub-second provisioning, snapshots and more.
 
 ## Features
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,11 @@ This project is ideal for developers, IT professionals, and organizations lookin
 
 Azure Sandbox is not intended for production use but serves as a powerful tool for learning and experimentation in Azure.
 
+> [!TIP]
+> **Looking for a different sandbox solution?**
+>
+> [**Azure Container Apps Sandboxes**](https://sandboxes.azure.com/) delivers production-grade isolation as a native Azure service — with default-deny egress control, sub-second provisioning, snapshots and more. [**Learn more →**](https://sandboxes.azure.com/)
+
 ## Features
 
 Azure Sandbox provides a comprehensive set of features to simplify the deployment and management of sandbox environments in Microsoft Azure.


### PR DESCRIPTION
## Summary

Improves the formatting of the Azure Container Apps Sandboxes callout in the README overview so it stands out.

- Converts the plain blockquote into a GitHub `[!TIP]` alert, which renders as a styled callout box (colored border, lightbulb icon, "Tip" label) on GitHub.
- Adopts the product group's suggested wording from #587, pointing readers to https://sandboxes.azure.com/.

## Notes

- The `[!TIP]` alert renders as a styled callout on GitHub.com. VS Code's built-in markdown preview may show it as a plain blockquote depending on version/extensions, but that is a local preview limitation only.
- Local CI checks (`markdown`, `links`) pass.

Fixes #587