### PR TITLE
Enable server-level auditing for Azure SQL Database (Fixes #39)

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ Multiple SQL database options are provided to suit various use cases and require
 * **Azure SQL Database (PaaS)**:
   * Deploys a fully managed Azure SQL Database instance.
   * Network isolated endpoints for secure access.
+  * Enables server-level auditing with audit logs routed to the shared Log Analytics workspace.
   * Simplifies database management by handling backups, scaling, and high availability.
   * Suitable for applications requiring a scalable and cost-effective relational database solution.
 

--- a/main.tf
+++ b/main.tf
@@ -299,14 +299,15 @@ module "mssql" {
 
   count = var.enable_module_mssql ? 1 : 0
 
-  location             = azurerm_resource_group.this.location
-  private_dns_zone_id  = module.vnet_app[0].private_dns_zones["privatelink.database.windows.net"].id
-  resource_group_name  = azurerm_resource_group.this.name
-  sql_admin_login_name = azuread_group.sql_admins[0].display_name
-  sql_admin_object_id  = azuread_group.sql_admins[0].object_id
-  subnet_id            = module.vnet_app[0].subnets["snet-privatelink-01"].id
-  tags                 = local.tags
-  unique_seed          = module.naming.unique-seed
+  location                   = azurerm_resource_group.this.location
+  log_analytics_workspace_id = module.vnet_shared.resource_ids["log_analytics_workspace"]
+  private_dns_zone_id        = module.vnet_app[0].private_dns_zones["privatelink.database.windows.net"].id
+  resource_group_name        = azurerm_resource_group.this.name
+  sql_admin_login_name       = azuread_group.sql_admins[0].display_name
+  sql_admin_object_id        = azuread_group.sql_admins[0].object_id
+  subnet_id                  = module.vnet_app[0].subnets["snet-privatelink-01"].id
+  tags                       = local.tags
+  unique_seed                = module.naming.unique-seed
 
   depends_on = [module.vnet_app[0].configure_azure_files_id] # Ensures that Azure Files is configured
 }

--- a/modules/mssql/README.md
+++ b/modules/mssql/README.md
@@ -82,6 +82,7 @@ This section lists input variables used in this module. Defaults can be overridd
 Variable | Default | Description
 --- | --- | ---
 location | | The name of the Azure Region where resources will be provisioned.
+log_analytics_workspace_id | | The ID of the Log Analytics workspace where SQL audit logs will be sent. Defined in the vnet-shared module.
 mssql_database_name | testdb | The name of the Azure SQL Database to be provisioned.
 private_dns_zone_id | | The ID of the private DNS zone for Azure SQL Database. Defined in the vnet-app module.
 resource_group_name | | The name of the resource group defined in the root module.
@@ -99,6 +100,8 @@ Address | Name | Notes
 --- | --- | ---
 module.mssql[0].azurerm_mssql_database.this | testdb | The Azure SQL Database.
 module.mssql[0].azurerm_mssql_server.this | sql&#8209;sand&#8209;dev&#8209;xxxxxxxx | The Azure SQL logical server.
+module.mssql[0].azurerm_mssql_server_extended_auditing_policy.this | | The server-level auditing policy that routes audit events to Azure Monitor (remediates VA2061).
+module.mssql[0].azurerm_monitor_diagnostic_setting.this | Audit Logs | The diagnostic setting that sends server audit logs (master database) to the Log Analytics workspace.
 module.mssql[0].azurerm_private_endpoint.this | pe&#8209;sand&#8209;dev&#8209;mssql&#8209;server | The private endpoint for the Azure SQL logical server.
 
 ### Output Variables

--- a/modules/mssql/main.tf
+++ b/modules/mssql/main.tf
@@ -25,6 +25,24 @@ resource "azurerm_mssql_database" "this" {
   server_id    = azurerm_mssql_server.this.id
   license_type = "BasePrice"
 }
+
+# Enables server-level auditing (remediates Defender for Cloud finding VA2061) by routing
+# audit events to Azure Monitor. The diagnostic setting on the server's 'master' database
+# completes the audit pipeline to the shared Log Analytics workspace.
+resource "azurerm_mssql_server_extended_auditing_policy" "this" {
+  server_id              = azurerm_mssql_server.this.id
+  log_monitoring_enabled = true
+}
+
+resource "azurerm_monitor_diagnostic_setting" "this" {
+  name                       = "Audit Logs"
+  target_resource_id         = "${azurerm_mssql_server.this.id}/databases/master"
+  log_analytics_workspace_id = var.log_analytics_workspace_id
+
+  enabled_log {
+    category = "SQLSecurityAuditEvents"
+  }
+}
 #endregion 
 
 #region modules

--- a/modules/mssql/scripts/Test-Mssql.ps1
+++ b/modules/mssql/scripts/Test-Mssql.ps1
@@ -160,6 +160,50 @@ catch {
     $failed++
 }
 
+# Test 6: Server-level auditing is enabled and audit events stream to Log Analytics (remediates VA2061)
+try {
+    $auditIssues = @()
+
+    # 6a: The extended auditing policy is enabled (Azure Monitor / Log Analytics target).
+    $audit = Get-AzSqlServerAudit -ResourceGroupName $ResourceGroupName -ServerName $MssqlServerName -ErrorAction Stop
+    if (-not $audit -or $audit.LogAnalyticsTargetState -ne 'Enabled') {
+        $auditIssues += "LogAnalyticsTargetState='$($audit.LogAnalyticsTargetState)' (expected 'Enabled')"
+    }
+
+    # 6b: A diagnostic setting on the server's master database enables the
+    #     SQLSecurityAuditEvents category and targets a Log Analytics workspace.
+    #     This is the canonical VA2061 remediation.
+    $auditServer = Get-AzSqlServer -ResourceGroupName $ResourceGroupName -ServerName $MssqlServerName -ErrorAction Stop
+    $masterResourceId = "$($auditServer.ResourceId)/databases/master"
+    $diagSettings = Get-AzDiagnosticSetting -ResourceId $masterResourceId -ErrorAction Stop
+
+    $auditDiag = $diagSettings | Where-Object {
+        $logs = $_.Log
+        $logs -and ($logs | Where-Object { $_.Category -eq 'SQLSecurityAuditEvents' -and $_.Enabled })
+    } | Select-Object -First 1
+
+    if (-not $auditDiag) {
+        $auditIssues += "no diagnostic setting on master database enables the 'SQLSecurityAuditEvents' log category"
+    }
+    elseif (-not $auditDiag.WorkspaceId) {
+        $auditIssues += "diagnostic setting '$($auditDiag.Name)' is not targeting a Log Analytics workspace"
+    }
+
+    if ($auditIssues.Count -eq 0) {
+        Write-TestResult $moduleName 'PASS' ("Server-level auditing is enabled and streaming 'SQLSecurityAuditEvents' to Log Analytics (remediates VA2061)")
+        $passed++
+    }
+    else {
+        Write-TestResult $moduleName 'FAIL' ("Server-level auditing issues: " + ($auditIssues -join '; '))
+        $failed++
+    }
+}
+catch {
+    Write-TestResult $moduleName 'FAIL' "Failed to verify server-level auditing for SQL server '$MssqlServerName'"
+    Write-TestResult $moduleName 'FAIL' "Exception: $_"
+    $failed++
+}
+
 # Summary
 $total = $passed + $failed
 Write-TestResult $moduleName 'SUMMARY' ("Passed: $passed Failed: $failed Total: $total")

--- a/modules/mssql/scripts/Test-Mssql.ps1
+++ b/modules/mssql/scripts/Test-Mssql.ps1
@@ -164,32 +164,19 @@ catch {
 try {
     $auditIssues = @()
 
-    # 6a: The extended auditing policy is enabled (Azure Monitor / Log Analytics target).
+    # Get-AzSqlServerAudit is the Azure SQL-native auditing cmdlet: LogAnalyticsTargetState
+    # and WorkspaceResourceId together reflect the master-database diagnostic setting that
+    # streams the SQLSecurityAuditEvents category to a Log Analytics workspace (the canonical
+    # VA2061 remediation). Using it avoids Get-AzDiagnosticSetting, whose Log/Metric output
+    # properties are being changed to List types in Az.Monitor 7.0.0.
     $audit = Get-AzSqlServerAudit -ResourceGroupName $ResourceGroupName -ServerName $MssqlServerName -ErrorAction Stop
+
     if (-not $audit -or $audit.LogAnalyticsTargetState -ne 'Enabled') {
         $auditIssues += "LogAnalyticsTargetState='$($audit.LogAnalyticsTargetState)' (expected 'Enabled')"
     }
 
-    # 6b: A diagnostic setting on the server's master database enables the
-    #     SQLSecurityAuditEvents category and targets a Log Analytics workspace.
-    #     This is the canonical VA2061 remediation.
-    $auditServer = Get-AzSqlServer -ResourceGroupName $ResourceGroupName -ServerName $MssqlServerName -ErrorAction Stop
-    $masterResourceId = "$($auditServer.ResourceId)/databases/master"
-    # -WarningAction SilentlyContinue suppresses the Az.Monitor breaking-change advisory
-    # for the Log/Metric output properties (they become List types in Az.Monitor 7.0.0).
-    # The category lookup below already works for both the current and future shapes.
-    $diagSettings = Get-AzDiagnosticSetting -ResourceId $masterResourceId -WarningAction SilentlyContinue -ErrorAction Stop
-
-    $auditDiag = $diagSettings | Where-Object {
-        $logs = $_.Log
-        $logs -and ($logs | Where-Object { $_.Category -eq 'SQLSecurityAuditEvents' -and $_.Enabled })
-    } | Select-Object -First 1
-
-    if (-not $auditDiag) {
-        $auditIssues += "no diagnostic setting on master database enables the 'SQLSecurityAuditEvents' log category"
-    }
-    elseif (-not $auditDiag.WorkspaceId) {
-        $auditIssues += "diagnostic setting '$($auditDiag.Name)' is not targeting a Log Analytics workspace"
+    if (-not $audit.WorkspaceResourceId) {
+        $auditIssues += 'auditing is not targeting a Log Analytics workspace (WorkspaceResourceId is empty)'
     }
 
     if ($auditIssues.Count -eq 0) {

--- a/modules/mssql/scripts/Test-Mssql.ps1
+++ b/modules/mssql/scripts/Test-Mssql.ps1
@@ -175,7 +175,10 @@ try {
     #     This is the canonical VA2061 remediation.
     $auditServer = Get-AzSqlServer -ResourceGroupName $ResourceGroupName -ServerName $MssqlServerName -ErrorAction Stop
     $masterResourceId = "$($auditServer.ResourceId)/databases/master"
-    $diagSettings = Get-AzDiagnosticSetting -ResourceId $masterResourceId -ErrorAction Stop
+    # -WarningAction SilentlyContinue suppresses the Az.Monitor breaking-change advisory
+    # for the Log/Metric output properties (they become List types in Az.Monitor 7.0.0).
+    # The category lookup below already works for both the current and future shapes.
+    $diagSettings = Get-AzDiagnosticSetting -ResourceId $masterResourceId -WarningAction SilentlyContinue -ErrorAction Stop
 
     $auditDiag = $diagSettings | Where-Object {
         $logs = $_.Log

--- a/modules/mssql/variables.tf
+++ b/modules/mssql/variables.tf
@@ -8,6 +8,16 @@ variable "location" {
   }
 }
 
+variable "log_analytics_workspace_id" {
+  type        = string
+  description = "The resource ID of the existing Log Analytics workspace where SQL audit logs will be sent. Defined in the vnet-shared module."
+
+  validation {
+    condition     = can(regex("^/subscriptions/[0-9a-fA-F-]+/resourceGroups/[a-zA-Z0-9-_()]+/providers/Microsoft.OperationalInsights/workspaces/[a-zA-Z0-9-_()]+$", var.log_analytics_workspace_id))
+    error_message = "Must be a valid Azure Resource ID for a Log Analytics workspace. It should follow the format '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.OperationalInsights/workspaces/{workspaceName}'."
+  }
+}
+
 variable "mssql_database_name" {
   type        = string
   description = "The name of the Azure SQL Database to be provisioned."


### PR DESCRIPTION
## Summary

Remediates Defender for Cloud finding **VA2061 — "Auditing should be enabled at the server level (Azure SQL Database)"** reported in #39.

The `mssql` module previously provisioned the logical server with no auditing configured. This PR enables **server-level auditing** and routes audit events to Azure Monitor.

## Changes

- **`modules/mssql/main.tf`**
  - `azurerm_mssql_server_extended_auditing_policy.this` with `log_monitoring_enabled = true`.
  - `azurerm_monitor_diagnostic_setting.this` targeting the server's `master` database, emitting the `SQLSecurityAuditEvents` category to the shared Log Analytics workspace. This is the Microsoft-documented pattern for server-level audit to Azure Monitor.
- **`modules/mssql/variables.tf`** — new `log_analytics_workspace_id` input (validated resource ID).
- **`main.tf`** — wires `log_analytics_workspace_id` from `module.vnet_shared.resource_ids["log_analytics_workspace"]`.
- **`README.md` / `modules/mssql/README.md`** — documentation updates (feature bullet, variables & resources tables).

## Design notes

- Uses the existing shared Log Analytics workspace, matching the repo's Key Vault audit-log convention — no new storage account required.
- Audit-event retention inherits the workspace's default retention (per-category retention on diagnostic settings is deprecated in `azurerm`).
- No public-access barrier wiring needed: the diagnostic setting and auditing policy are control-plane resources, not data-plane writes.

## Validation

- `terraform fmt` ✅, `terraform validate` ✅
- `./scripts/Invoke-CIChecks.sh` (full suite) → **No failures** (bash, powershell, markdown, links, actions, secrets, terraform fmt, tflint all pass).

Fixes #39