### PR TITLE
Configure observability for Azure MySQL Flexible Server (mysql module)

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ Multiple SQL database options are provided to suit various use cases and require
 * **Azure Database for MySQL (PaaS)**:
   * Deploys a fully managed MySQL database instance.
   * Network isolated endpoints for secure access.
+  * Enables slow query and audit logging with logs and metrics routed to the shared Log Analytics workspace.
   * Provides high availability, automated backups, and scaling options.
   * Ideal for applications built on open-source technologies requiring MySQL as the backend database.
 

--- a/main.tf
+++ b/main.tf
@@ -317,14 +317,15 @@ module "mysql" {
 
   count = var.enable_module_mysql ? 1 : 0
 
-  admin_password      = module.vnet_shared.admin_password
-  admin_username      = module.vnet_shared.admin_username
-  location            = azurerm_resource_group.this.location
-  private_dns_zone_id = module.vnet_app[0].private_dns_zones["privatelink.mysql.database.azure.com"].id
-  resource_group_name = azurerm_resource_group.this.name
-  subnet_id           = module.vnet_app[0].subnets["snet-privatelink-01"].id
-  tags                = local.tags
-  unique_seed         = module.naming.unique-seed
+  admin_password             = module.vnet_shared.admin_password
+  admin_username             = module.vnet_shared.admin_username
+  location                   = azurerm_resource_group.this.location
+  log_analytics_workspace_id = module.vnet_shared.resource_ids["log_analytics_workspace"]
+  private_dns_zone_id        = module.vnet_app[0].private_dns_zones["privatelink.mysql.database.azure.com"].id
+  resource_group_name        = azurerm_resource_group.this.name
+  subnet_id                  = module.vnet_app[0].subnets["snet-privatelink-01"].id
+  tags                       = local.tags
+  unique_seed                = module.naming.unique-seed
 
   depends_on = [module.vnet_app[0].configure_azure_files_id] # Ensures that Azure Files is configured
 }

--- a/modules/mysql/README.md
+++ b/modules/mysql/README.md
@@ -83,6 +83,7 @@ Variable | Default | Description
 admin_password |  | A strong password used for admin accounts. Defined in the vnet-shared module.
 admin_username | bootstrapadmin | The user name used for admin accounts. Defined in the vnet-shared module.
 location | | The name of the Azure Region where resources will be provisioned. Defined in the root module.
+log_analytics_workspace_id | | The ID of the Log Analytics workspace where MySQL diagnostic logs and metrics will be sent. Defined in the vnet-shared module.
 mysql_database_name | testdb | The name of the Azure MySQL Database to be provisioned.
 mysql_sku_name | B_Standard_B1ms | The SKU name for the Azure MySQL Flexible Server.
 private_dns_zone_id | | The ID of the private DNS zone for Azure Database for MySQL. Defined in the vnet-app module.
@@ -99,6 +100,10 @@ Address | Name | Notes
 --- | --- | ---
 module.mysql[0].azurerm_mysql_flexible_database.this | testdb | The Azure MySQL Database.
 module.mysql[0].azurerm_mysql_flexible_server.this | mysql&#8209;sand&#8209;dev&#8209;xxxxxxxx | The Azure MySQL flexible server.
+module.mysql[0].azurerm_mysql_flexible_server_configuration.slow_query_log | slow_query_log | Enables slow query logging so the *MySqlSlowLogs* diagnostic category produces data.
+module.mysql[0].azurerm_mysql_flexible_server_configuration.audit_log_enabled | audit_log_enabled | Enables audit logging so the *MySqlAuditLogs* diagnostic category produces data.
+module.mysql[0].azurerm_mysql_flexible_server_configuration.audit_log_events | audit_log_events | Selects the audit event classes (CONNECTION, DML, DDL, DCL) to be logged.
+module.mysql[0].azurerm_monitor_diagnostic_setting.this | Diagnostic Logs | The diagnostic setting that sends MySQL slow/audit logs and metrics to the Log Analytics workspace.
 module.mysql[0].azurerm_private_endpoint.this | pe&#8209;sand&#8209;dev&#8209;mysql&#8209;server | The private endpoint for the Azure MySQL flexible server.
 
 ### Output Variables

--- a/modules/mysql/main.tf
+++ b/modules/mysql/main.tf
@@ -16,6 +16,54 @@ resource "azurerm_mysql_flexible_database" "this" {
   charset             = "utf8"
   collation           = "utf8_unicode_ci"
 }
+
+# Server parameters that must be enabled for the diagnostic categories below to produce data.
+resource "azurerm_mysql_flexible_server_configuration" "slow_query_log" {
+  name                = "slow_query_log"
+  resource_group_name = var.resource_group_name
+  server_name         = azurerm_mysql_flexible_server.this.name
+  value               = "ON"
+}
+
+resource "azurerm_mysql_flexible_server_configuration" "audit_log_enabled" {
+  name                = "audit_log_enabled"
+  resource_group_name = var.resource_group_name
+  server_name         = azurerm_mysql_flexible_server.this.name
+  value               = "ON"
+}
+
+resource "azurerm_mysql_flexible_server_configuration" "audit_log_events" {
+  name                = "audit_log_events"
+  resource_group_name = var.resource_group_name
+  server_name         = azurerm_mysql_flexible_server.this.name
+  value               = "CONNECTION,DML,DDL,DCL"
+}
+
+# Routes MySQL slow/audit logs and metrics to the shared Log Analytics workspace owned by
+# the vnet-shared module. Depends on the server parameters above so the categories emit data.
+resource "azurerm_monitor_diagnostic_setting" "this" {
+  name                       = "Diagnostic Logs"
+  target_resource_id         = azurerm_mysql_flexible_server.this.id
+  log_analytics_workspace_id = var.log_analytics_workspace_id
+
+  enabled_log {
+    category = "MySqlSlowLogs"
+  }
+
+  enabled_log {
+    category = "MySqlAuditLogs"
+  }
+
+  enabled_metric {
+    category = "AllMetrics"
+  }
+
+  depends_on = [
+    azurerm_mysql_flexible_server_configuration.slow_query_log,
+    azurerm_mysql_flexible_server_configuration.audit_log_enabled,
+    azurerm_mysql_flexible_server_configuration.audit_log_events
+  ]
+}
 #endregion
 
 #region modules

--- a/modules/mysql/scripts/Test-Mysql.ps1
+++ b/modules/mysql/scripts/Test-Mysql.ps1
@@ -150,6 +150,52 @@ catch {
     $failed++
 }
 
+# Test 6: Diagnostic setting streams MySQL logs and metrics to Log Analytics
+try {
+    $server = Get-AzResource -ResourceGroupName $ResourceGroupName -ResourceType 'Microsoft.DBforMySQL/flexibleServers' -Name $MysqlServerName -ErrorAction Stop
+
+    # Get-AzDiagnosticSetting Log/Metric output properties are changing to List types in
+    # Az.Monitor 7.0.0; query the diagnostic settings via the REST API to stay version-agnostic.
+    $uri = "$($server.ResourceId)/providers/Microsoft.Insights/diagnosticSettings?api-version=2021-05-01-preview"
+    $response = Invoke-AzRestMethod -Method GET -Path $uri -ErrorAction Stop
+    $settings = ($response.Content | ConvertFrom-Json).value
+
+    $diagIssues = @()
+
+    $laSetting = $settings | Where-Object { $_.properties.workspaceId } | Select-Object -First 1
+
+    if (-not $laSetting) {
+        $diagIssues += 'no diagnostic setting targeting a Log Analytics workspace found'
+    }
+    else {
+        $enabledLogs = @($laSetting.properties.logs | Where-Object { $_.enabled } | ForEach-Object { $_.category })
+        foreach ($category in @('MySqlSlowLogs', 'MySqlAuditLogs')) {
+            if ($enabledLogs -notcontains $category) {
+                $diagIssues += "log category '$category' is not enabled"
+            }
+        }
+
+        $metricsEnabled = @($laSetting.properties.metrics | Where-Object { $_.enabled -and $_.category -eq 'AllMetrics' })
+        if ($metricsEnabled.Count -eq 0) {
+            $diagIssues += "metric category 'AllMetrics' is not enabled"
+        }
+    }
+
+    if ($diagIssues.Count -eq 0) {
+        Write-TestResult $moduleName 'PASS' ("Diagnostic setting '$($laSetting.name)' streams 'MySqlSlowLogs', 'MySqlAuditLogs', and 'AllMetrics' to Log Analytics")
+        $passed++
+    }
+    else {
+        Write-TestResult $moduleName 'FAIL' ("Diagnostic setting issues: " + ($diagIssues -join '; '))
+        $failed++
+    }
+}
+catch {
+    Write-TestResult $moduleName 'FAIL' "Failed to verify diagnostic setting for MySQL Flexible Server '$MysqlServerName'"
+    Write-TestResult $moduleName 'FAIL' "Exception: $_"
+    $failed++
+}
+
 # Summary
 $total = $passed + $failed
 Write-TestResult $moduleName 'SUMMARY' ("Passed: $passed Failed: $failed Total: $total")

--- a/modules/mysql/variables.tf
+++ b/modules/mysql/variables.tf
@@ -29,6 +29,16 @@ variable "location" {
   }
 }
 
+variable "log_analytics_workspace_id" {
+  type        = string
+  description = "The resource ID of the existing Log Analytics workspace where MySQL diagnostic logs and metrics will be sent. Defined in the vnet-shared module."
+
+  validation {
+    condition     = can(regex("^/subscriptions/[0-9a-fA-F-]+/resourceGroups/[a-zA-Z0-9-_()]+/providers/Microsoft.OperationalInsights/workspaces/[a-zA-Z0-9-_()]+$", var.log_analytics_workspace_id))
+    error_message = "Must be a valid Azure Resource ID for a Log Analytics workspace. It should follow the format '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.OperationalInsights/workspaces/{workspaceName}'."
+  }
+}
+
 variable "mysql_database_name" {
   type        = string
   description = "The name of the Azure MySQL Database to be provisioned."


### PR DESCRIPTION
Fixes #607.

Wires the observability framework (diagnostic settings → shared Log Analytics workspace owned by `vnet-shared`) into the `mysql` module, mirroring the `mssql` integration from #606.

## Changes

- **`modules/mysql/main.tf`**
  - Add `azurerm_monitor_diagnostic_setting.this` on the flexible server, emitting the `MySqlSlowLogs` and `MySqlAuditLogs` log categories and `AllMetrics` to the shared Log Analytics workspace.
  - Enable the required server parameters via `azurerm_mysql_flexible_server_configuration` (`slow_query_log = ON`, `audit_log_enabled = ON`, `audit_log_events = CONNECTION,DML,DDL,DCL`) so the diagnostic categories actually produce data. The diagnostic setting `depends_on` these so parameters are applied first.
- **`modules/mysql/variables.tf`** — add validated `log_analytics_workspace_id` input.
- **`main.tf`** (root) — wire `log_analytics_workspace_id = module.vnet_shared.resource_ids["log_analytics_workspace"]`, mirroring `mssql`.
- **`modules/mysql/scripts/Test-Mysql.ps1`** — add Test 6 verifying the diagnostic setting targets a Log Analytics workspace and enables the expected log/metric categories.
- **Docs** — update `modules/mysql/README.md` (input variables + resources tables) and root `README.md`.

Diagnostic settings are control-plane, so no public-access data-plane barrier wiring is required (confirmed — consistent with the `mssql` precedent).

## Acceptance criteria

- [x] MySQL slow/audit logs and metrics flow to the shared Log Analytics workspace.
- [x] New `log_analytics_workspace_id` variable added and wired from root.
- [x] Unit test added to verify the diagnostic setting exists (mirrors `Test-Mssql.ps1`).
- [x] `modules/mysql/README.md` and root `README.md` updated.
- [x] `./scripts/Invoke-CIChecks.sh terraform markdown` passes (also ran `powershell`). `terraform init` + `validate` succeed.