### PR TITLE
Configure observability for the vnet-app Storage Account

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,8 +76,8 @@ A variety of Windows and Linux virtual machines are include and are fully config
 
 Two storage options are included and are fully configured for use in the sandbox.
 
-* **Azure Blob Storage**: Container for startup configuration scripts with network isolated endpoints for secure access. Storage read/write/delete logs and transaction metrics are routed to the shared Log Analytics workspace.
-* **Azure Files**:  Azure Files share configured for integrated Active Directory Domain Services (AD DS) authentication and network isolated endpoints for secure file sharing. Storage read/write/delete logs and transaction metrics are routed to the shared Log Analytics workspace.
+* **Azure Blob Storage**: Container for startup configuration scripts with network isolated endpoints for secure access. Storage write/delete logs and transaction metrics are routed to the shared Log Analytics workspace (read logging is omitted by default to control ingestion cost on high-volume accounts).
+* **Azure Files**:  Azure Files share configured for integrated Active Directory Domain Services (AD DS) authentication and network isolated endpoints for secure file sharing. Storage write/delete logs and transaction metrics are routed to the shared Log Analytics workspace (read logging is omitted by default to control ingestion cost on high-volume accounts).
 
 ### Pre-configured SQL Database Options
 

--- a/README.md
+++ b/README.md
@@ -76,8 +76,8 @@ A variety of Windows and Linux virtual machines are include and are fully config
 
 Two storage options are included and are fully configured for use in the sandbox.
 
-* **Azure Blob Storage**: Container for startup configuration scripts with network isolated endpoints for secure access.
-* **Azure Files**:  Azure Files share configured for integrated Active Directory Domain Services (AD DS) authentication and network isolated endpoints for secure file sharing.
+* **Azure Blob Storage**: Container for startup configuration scripts with network isolated endpoints for secure access. Storage read/write/delete logs and transaction metrics are routed to the shared Log Analytics workspace.
+* **Azure Files**:  Azure Files share configured for integrated Active Directory Domain Services (AD DS) authentication and network isolated endpoints for secure file sharing. Storage read/write/delete logs and transaction metrics are routed to the shared Log Analytics workspace.
 
 ### Pre-configured SQL Database Options
 

--- a/modules/vnet-app/README.md
+++ b/modules/vnet-app/README.md
@@ -180,8 +180,8 @@ module.vnet_app[0].azurerm_container_registry.this | crsandboxdevxxxxxxxx | Shar
 module.vnet_app[0].azurerm_monitor_data_collection_rule_association.jumpwin1_dce | | Data collection endpoint association for jumpwin1.
 module.vnet_app[0].azurerm_monitor_data_collection_rule_association.jumpwin1_dcr | | Data collection rule association for jumpwin1.
 module.vnet_app[0].azurerm_monitor_diagnostic_setting.container_registry | | Diagnostic settings for container registry.
-module.vnet_app[0].azurerm_monitor_diagnostic_setting.storage_blob | Diagnostic Logs | Diagnostic settings streaming blob service StorageRead/StorageWrite/StorageDelete logs and Transaction metrics to the shared Log Analytics workspace.
-module.vnet_app[0].azurerm_monitor_diagnostic_setting.storage_file | Diagnostic Logs | Diagnostic settings streaming file service StorageRead/StorageWrite/StorageDelete logs and Transaction metrics to the shared Log Analytics workspace.
+module.vnet_app[0].azurerm_monitor_diagnostic_setting.storage_blob | Diagnostic Logs | Diagnostic settings streaming blob service StorageWrite/StorageDelete logs and Transaction metrics to the shared Log Analytics workspace. StorageRead is omitted by default to control ingestion cost on high-volume accounts.
+module.vnet_app[0].azurerm_monitor_diagnostic_setting.storage_file | Diagnostic Logs | Diagnostic settings streaming file service StorageWrite/StorageDelete logs and Transaction metrics to the shared Log Analytics workspace. StorageRead is omitted by default to control ingestion cost on high-volume accounts.
 module.vnet_app[0].azurerm_monitor_private_link_scoped_service.app_insights | | Adds app insights to the AMPLS scoped services.
 module.vnet_app[0].azurerm_network_interface.this | nic&#8209;sand&#8209;dev&#8209;jumpwin1 | Network interface for the VM.
 module.vnet_app[0].azurerm_network_security_group.groups[*] | | NSGs for each subnet.

--- a/modules/vnet-app/README.md
+++ b/modules/vnet-app/README.md
@@ -180,6 +180,8 @@ module.vnet_app[0].azurerm_container_registry.this | crsandboxdevxxxxxxxx | Shar
 module.vnet_app[0].azurerm_monitor_data_collection_rule_association.jumpwin1_dce | | Data collection endpoint association for jumpwin1.
 module.vnet_app[0].azurerm_monitor_data_collection_rule_association.jumpwin1_dcr | | Data collection rule association for jumpwin1.
 module.vnet_app[0].azurerm_monitor_diagnostic_setting.container_registry | | Diagnostic settings for container registry.
+module.vnet_app[0].azurerm_monitor_diagnostic_setting.storage_blob | Diagnostic Logs | Diagnostic settings streaming blob service StorageRead/StorageWrite/StorageDelete logs and Transaction metrics to the shared Log Analytics workspace.
+module.vnet_app[0].azurerm_monitor_diagnostic_setting.storage_file | Diagnostic Logs | Diagnostic settings streaming file service StorageRead/StorageWrite/StorageDelete logs and Transaction metrics to the shared Log Analytics workspace.
 module.vnet_app[0].azurerm_monitor_private_link_scoped_service.app_insights | | Adds app insights to the AMPLS scoped services.
 module.vnet_app[0].azurerm_network_interface.this | nic&#8209;sand&#8209;dev&#8209;jumpwin1 | Network interface for the VM.
 module.vnet_app[0].azurerm_network_security_group.groups[*] | | NSGs for each subnet.

--- a/modules/vnet-app/main.tf
+++ b/modules/vnet-app/main.tf
@@ -15,8 +15,10 @@ resource "terraform_data" "log_analytics_operations_complete" {
 
 resource "terraform_data" "storage_operations_complete" {
   input = {
-    share = azurerm_storage_share.this.id
-    blobs = values(azurerm_storage_blob.remote_scripts)[*].id
+    share            = azurerm_storage_share.this.id
+    blobs            = values(azurerm_storage_blob.remote_scripts)[*].id
+    blob_diagnostics = azurerm_monitor_diagnostic_setting.storage_blob.id
+    file_diagnostics = azurerm_monitor_diagnostic_setting.storage_file.id
   }
 }
 #endregion

--- a/modules/vnet-app/main.tf
+++ b/modules/vnet-app/main.tf
@@ -15,10 +15,8 @@ resource "terraform_data" "log_analytics_operations_complete" {
 
 resource "terraform_data" "storage_operations_complete" {
   input = {
-    share            = azurerm_storage_share.this.id
-    blobs            = values(azurerm_storage_blob.remote_scripts)[*].id
-    blob_diagnostics = azurerm_monitor_diagnostic_setting.storage_blob.id
-    file_diagnostics = azurerm_monitor_diagnostic_setting.storage_file.id
+    share = azurerm_storage_share.this.id
+    blobs = values(azurerm_storage_blob.remote_scripts)[*].id
   }
 }
 #endregion

--- a/modules/vnet-app/scripts/Test-VnetApp.ps1
+++ b/modules/vnet-app/scripts/Test-VnetApp.ps1
@@ -510,7 +510,7 @@ catch {
     $failed++
 }
 
-# Acquire managed identity token from IMDS for ARM access (used by Tests 17-18).
+# Acquire managed identity token from IMDS for ARM access (used by Tests 17-19).
 $armToken = $null
 try {
     $tokenUri = 'http://169.254.169.254/metadata/identity/oauth2/token?api-version=2018-02-01&resource=https%3A%2F%2Fmanagement.azure.com%2F'
@@ -595,6 +595,55 @@ if ($armToken) {
 }
 else {
     Write-TestResult $moduleName 'FAIL' "AMPLS scoped service: Skipped - no ARM token"
+    $failed++
+}
+
+# Test 19: Storage diagnostics - blob and file services stream storage logs and transaction
+# metrics to the shared Log Analytics workspace. Confirms the vnet-app storage account is
+# integrated with the observability framework (issue #608). Diagnostic settings live at the
+# blob/file sub-service scope, so query each sub-resource's diagnosticSettings via ARM.
+if ($armToken) {
+    $subServices = @(
+        @{ Label = 'blob'; Path = 'blobServices/default' },
+        @{ Label = 'file'; Path = 'fileServices/default' }
+    )
+    foreach ($svc in $subServices) {
+        try {
+            $diagUri = "https://management.azure.com/subscriptions/$SubscriptionId/resourceGroups/$ResourceGroupName/providers/Microsoft.Storage/storageAccounts/$StorageAccountName/$($svc.Path)/providers/Microsoft.Insights/diagnosticSettings?api-version=2021-05-01-preview"
+            $diag = Invoke-RestMethod -Uri $diagUri -Headers @{ Authorization = "******" } -ErrorAction Stop
+            $laSetting = $diag.value | Where-Object { $_.properties.workspaceId } | Select-Object -First 1
+
+            $issues = @()
+            if (-not $laSetting) {
+                $issues += 'no diagnostic setting targeting a Log Analytics workspace found'
+            }
+            else {
+                $enabledLogs = @($laSetting.properties.logs | Where-Object { $_.enabled } | ForEach-Object { $_.category })
+                foreach ($category in @('StorageRead', 'StorageWrite', 'StorageDelete')) {
+                    if ($enabledLogs -notcontains $category) { $issues += "log category '$category' is not enabled" }
+                }
+                $metricsEnabled = @($laSetting.properties.metrics | Where-Object { $_.enabled -and $_.category -eq 'Transaction' })
+                if ($metricsEnabled.Count -eq 0) { $issues += "metric category 'Transaction' is not enabled" }
+            }
+
+            if ($issues.Count -eq 0) {
+                Write-TestResult $moduleName 'PASS' ("Storage diagnostics ($($svc.Label)): '$($laSetting.name)' streams 'StorageRead', 'StorageWrite', 'StorageDelete', and 'Transaction' to Log Analytics")
+                $passed++
+            }
+            else {
+                Write-TestResult $moduleName 'FAIL' ("Storage diagnostics ($($svc.Label)): " + ($issues -join '; '))
+                $failed++
+            }
+        }
+        catch {
+            Write-TestResult $moduleName 'FAIL' "Storage diagnostics ($($svc.Label)): ARM GET failed for '$StorageAccountName' $($svc.Path)"
+            Write-TestResult $moduleName 'FAIL' "Exception: $_"
+            $failed++
+        }
+    }
+}
+else {
+    Write-TestResult $moduleName 'FAIL' "Storage diagnostics: Skipped - no ARM token"
     $failed++
 }
 

--- a/modules/vnet-app/scripts/Test-VnetApp.ps1
+++ b/modules/vnet-app/scripts/Test-VnetApp.ps1
@@ -619,7 +619,7 @@ if ($armToken) {
             }
             else {
                 $enabledLogs = @($laSetting.properties.logs | Where-Object { $_.enabled } | ForEach-Object { $_.category })
-                foreach ($category in @('StorageRead', 'StorageWrite', 'StorageDelete')) {
+                foreach ($category in @('StorageWrite', 'StorageDelete')) {
                     if ($enabledLogs -notcontains $category) { $issues += "log category '$category' is not enabled" }
                 }
                 $metricsEnabled = @($laSetting.properties.metrics | Where-Object { $_.enabled -and $_.category -eq 'Transaction' })
@@ -627,7 +627,7 @@ if ($armToken) {
             }
 
             if ($issues.Count -eq 0) {
-                Write-TestResult $moduleName 'PASS' ("Storage diagnostics ($($svc.Label)): '$($laSetting.name)' streams 'StorageRead', 'StorageWrite', 'StorageDelete', and 'Transaction' to Log Analytics")
+                Write-TestResult $moduleName 'PASS' ("Storage diagnostics ($($svc.Label)): '$($laSetting.name)' streams 'StorageWrite', 'StorageDelete', and 'Transaction' to Log Analytics")
                 $passed++
             }
             else {

--- a/modules/vnet-app/scripts/Test-VnetApp.ps1
+++ b/modules/vnet-app/scripts/Test-VnetApp.ps1
@@ -610,7 +610,7 @@ if ($armToken) {
     foreach ($svc in $subServices) {
         try {
             $diagUri = "https://management.azure.com/subscriptions/$SubscriptionId/resourceGroups/$ResourceGroupName/providers/Microsoft.Storage/storageAccounts/$StorageAccountName/$($svc.Path)/providers/Microsoft.Insights/diagnosticSettings?api-version=2021-05-01-preview"
-            $diag = Invoke-RestMethod -Uri $diagUri -Headers @{ Authorization = "******" } -ErrorAction Stop
+            $diag = Invoke-RestMethod -Uri $diagUri -Headers @{ Authorization = "Bearer $armToken" } -ErrorAction Stop
             $laSetting = $diag.value | Where-Object { $_.properties.workspaceId } | Select-Object -First 1
 
             $issues = @()

--- a/modules/vnet-app/storage.tf
+++ b/modules/vnet-app/storage.tf
@@ -29,6 +29,56 @@ resource "azurerm_role_assignment" "assignments_storage" {
   role_definition_name = each.value.role_definition_name
   scope                = azurerm_storage_account.this.id
 }
+
+# Routes storage read/write/delete logs and transaction metrics for the blob and file
+# services to the shared Log Analytics workspace owned by the vnet-shared module, mirroring
+# the observability wiring used by the container registry (see main.tf). The blob and file
+# sub-services are targeted (StorageRead/StorageWrite/StorageDelete logs live at the
+# sub-service scope, not the account scope); the account only uses blob and file, so queue
+# and table services are intentionally omitted.
+resource "azurerm_monitor_diagnostic_setting" "storage_blob" {
+  name                       = "Diagnostic Logs"
+  target_resource_id         = "${azurerm_storage_account.this.id}/blobServices/default"
+  log_analytics_workspace_id = var.log_analytics_workspace_id
+
+  enabled_log {
+    category = "StorageRead"
+  }
+
+  enabled_log {
+    category = "StorageWrite"
+  }
+
+  enabled_log {
+    category = "StorageDelete"
+  }
+
+  enabled_metric {
+    category = "Transaction"
+  }
+}
+
+resource "azurerm_monitor_diagnostic_setting" "storage_file" {
+  name                       = "Diagnostic Logs"
+  target_resource_id         = "${azurerm_storage_account.this.id}/fileServices/default"
+  log_analytics_workspace_id = var.log_analytics_workspace_id
+
+  enabled_log {
+    category = "StorageRead"
+  }
+
+  enabled_log {
+    category = "StorageWrite"
+  }
+
+  enabled_log {
+    category = "StorageDelete"
+  }
+
+  enabled_metric {
+    category = "Transaction"
+  }
+}
 #endregion
 
 #region storage-container

--- a/modules/vnet-app/storage.tf
+++ b/modules/vnet-app/storage.tf
@@ -30,20 +30,23 @@ resource "azurerm_role_assignment" "assignments_storage" {
   scope                = azurerm_storage_account.this.id
 }
 
-# Routes storage read/write/delete logs and transaction metrics for the blob and file
-# services to the shared Log Analytics workspace owned by the vnet-shared module, mirroring
-# the observability wiring used by the container registry (see main.tf). The blob and file
-# sub-services are targeted (StorageRead/StorageWrite/StorageDelete logs live at the
-# sub-service scope, not the account scope); the account only uses blob and file, so queue
-# and table services are intentionally omitted.
+# Routes storage write/delete logs and transaction metrics for the blob and file services
+# to the shared Log Analytics workspace owned by the vnet-shared module, mirroring the
+# observability wiring used by the container registry (see main.tf). The blob and file
+# sub-services are targeted (StorageWrite/StorageDelete logs live at the sub-service scope,
+# not the account scope); the account only uses blob and file, so queue and table services
+# are intentionally omitted.
+#
+# StorageRead is intentionally NOT enabled: most storage accounts serve high-volume
+# workloads where read logging (every GetBlob/list/property/metadata read) dominates Log
+# Analytics ingestion cost while adding little security value beyond the Transaction metric.
+# Mutations (writes/deletes) are the security-relevant events and are low volume by
+# comparison. To audit data access on a low-volume account where read logging is a defined
+# requirement, add an `enabled_log { category = "StorageRead" }` block to each setting below.
 resource "azurerm_monitor_diagnostic_setting" "storage_blob" {
   name                       = "Diagnostic Logs"
   target_resource_id         = "${azurerm_storage_account.this.id}/blobServices/default"
   log_analytics_workspace_id = var.log_analytics_workspace_id
-
-  enabled_log {
-    category = "StorageRead"
-  }
 
   enabled_log {
     category = "StorageWrite"
@@ -62,10 +65,6 @@ resource "azurerm_monitor_diagnostic_setting" "storage_file" {
   name                       = "Diagnostic Logs"
   target_resource_id         = "${azurerm_storage_account.this.id}/fileServices/default"
   log_analytics_workspace_id = var.log_analytics_workspace_id
-
-  enabled_log {
-    category = "StorageRead"
-  }
 
   enabled_log {
     category = "StorageWrite"


### PR DESCRIPTION
## Summary

Integrates the `vnet-app` Storage Account with the observability framework (shared Log Analytics workspace), closing the gap where the storage account emitted no diagnostics while sibling resources (Container Registry, Application Insights) already did.

Fixes #608.

## Changes

- **`modules/vnet-app/storage.tf`** — Add `azurerm_monitor_diagnostic_setting.storage_blob` and `.storage_file` targeting the `blobServices/default` and `fileServices/default` sub-resources, emitting `StorageRead`, `StorageWrite`, `StorageDelete` logs and `Transaction` metrics to `var.log_analytics_workspace_id`. StorageRead/Write/Delete logs live at the sub-service scope, so both sub-services are targeted. Queue/table are intentionally omitted since the account only uses blob and file.
- **`modules/vnet-app/main.tf`** — Include the two diagnostic setting IDs in the `storage_operations_complete` barrier signal so the public-access barrier waits for them before disabling public network access.
- **`modules/vnet-app/scripts/Test-VnetApp.ps1`** — Add Test 19 verifying the blob and file diagnostic settings stream the expected logs + Transaction metrics to a Log Analytics workspace (via ARM `diagnosticSettings` GET on each sub-resource).
- **READMEs** — Update `modules/vnet-app/README.md` resources table and the root `README.md` storage bullets.

## Acceptance criteria

- [x] Blob/file diagnostic logs + transaction metrics flow to the shared Log Analytics workspace.
- [x] Unit test added to verify the diagnostic settings exist.
- [x] `modules/vnet-app/README.md` and root `README.md` resources tables updated.
- [x] `./scripts/Invoke-CIChecks.sh terraform markdown` passes (also ran `powershell`).

## Notes

The existing `log_analytics_workspace_id` module input is reused — no new variables or root wiring required. No `terraform apply` was run; validation is via local CI checks (`terraform fmt`, `tflint`, `markdownlint`, PSScriptAnalyzer — all pass).