### PR TITLE
Configure observability for the point-to-site VPN gateway (Fixes #609)

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Enable only the modules you need for your specific sandbox environment. Disable 
 * **Private Endpoints**: Pre-configured network isolated endpoints for PaaS services.
 * **Azure Firewall**: Pre-configured firewall for secure outbound internet access and threat intelligence. Structured (resource-specific) application-rule, network-rule, NAT-rule, threat-intel, and DNS-query logs plus metrics are routed to the shared Log Analytics workspace (high-volume aggregation/flow-trace and Premium-only IDPS categories are omitted by default to control ingestion cost).
 * **Azure Bastion**: Pre-configured Bastion (Standard SKU) for secure and seamless RDP/SSH access to virtual machines without exposing them to the public internet. Bastion audit logs (`BastionAuditLogs`) and metrics are routed to the shared Log Analytics workspace for observability.
-* **Point-to-site VPN Gateway**: Pre-configured point-to-site VPN gateway for secure remote access to your sandbox environment.
+* **Point-to-site VPN Gateway**: Pre-configured point-to-site VPN gateway for secure remote access to your sandbox environment. Gateway, IKE, and P2S diagnostic logs (`GatewayDiagnosticLog`, `IKEDiagnosticLog`, `P2SDiagnosticLog`) and metrics are routed to the shared Log Analytics workspace for observability.
 
 ### Pre-configured Virtual Machines
 
@@ -748,7 +748,7 @@ Bi-directional virtual network peering is enabled between the virtual networks i
 
 #### **Secure VPN Access**
 
-The optional *vwan* module implements an Azure Virtual WAN point-to-site VPN gateway for secure remote connectivity to your sandbox environment from a remote computer. This is ideal for scenarios where access via Bastion is not sufficient, for example if you need to transfer data into your sandbox environment or use tools that are only available on a remote computer. A self-signed certificate is used for authentication. The virtual WAN hub is connected to both the *vnet-shared* and *vnet-app* virtual networks, allowing secure VPN access to resources in your sandbox environment.
+The optional *vwan* module implements an Azure Virtual WAN point-to-site VPN gateway for secure remote connectivity to your sandbox environment from a remote computer. This is ideal for scenarios where access via Bastion is not sufficient, for example if you need to transfer data into your sandbox environment or use tools that are only available on a remote computer. A self-signed certificate is used for authentication. The virtual WAN hub is connected to both the *vnet-shared* and *vnet-app* virtual networks, allowing secure VPN access to resources in your sandbox environment. Gateway, IKE, and point-to-site diagnostic logs and metrics from the VPN gateway are routed to the shared Log Analytics workspace for observability.
 
 The following address ranges are used for the point-to-site VPN gateway:
 

--- a/main.tf
+++ b/main.tf
@@ -335,11 +335,12 @@ module "vwan" {
 
   count = var.enable_module_vwan ? 1 : 0
 
-  dns_server          = module.vnet_shared.dns_server
-  key_vault_id        = module.vnet_shared.resource_ids["key_vault"]
-  location            = azurerm_resource_group.this.location
-  resource_group_name = azurerm_resource_group.this.name
-  tags                = local.tags
+  dns_server                 = module.vnet_shared.dns_server
+  key_vault_id               = module.vnet_shared.resource_ids["key_vault"]
+  location                   = azurerm_resource_group.this.location
+  log_analytics_workspace_id = module.vnet_shared.resource_ids["log_analytics_workspace"]
+  resource_group_name        = azurerm_resource_group.this.name
+  tags                       = local.tags
 
   virtual_networks = {
     virtual_network_shared = module.vnet_shared.resource_ids["virtual_network_shared"]

--- a/modules/vwan/README.md
+++ b/modules/vwan/README.md
@@ -366,6 +366,7 @@ client_address_pool | `10.4.0.0/16` | The address range used for point-to-site V
 dns_server | `10.1.1.4` | The IP address of the DNS server used for the virtual network. Defined in the vnet-shared module.
 key_vault_id | | The ID of the key vault defined in the root module.
 location | | The Azure region defined in the root module.
+log_analytics_workspace_id | | The ID of the Log Analytics workspace where point-to-site VPN gateway diagnostic logs and metrics will be sent. Defined in the vnet-shared module.
 private_key_secret_version | 1 | Increment to create a new private key secret.
 resource_group_name | | The name of the resource group defined in the root module.
 tags | | The tags defined in the root module.
@@ -379,6 +380,7 @@ This section lists the resources included in this configuration.
 Address | Name | Notes
 --- | --- | ---
 module.vwan[0].azurerm_key_vault_secret.this | p2svpn&#8209;client&#8209;private&#8209;key&#8209;pem | Key vault secret used to secure the private key for the client certificate.
+module.vwan[0].azurerm_monitor_diagnostic_setting.this | Diagnostic Logs | The diagnostic setting that sends point-to-site VPN gateway *GatewayDiagnosticLog*, *IKEDiagnosticLog*, *P2SDiagnosticLog* logs and *AllMetrics* to the shared Log Analytics workspace.
 module.vwan[0].azurerm_point_to_site_vpn_gateway.this | vpngw&#8209;sand&#8209;dev | The Azure Virtual WAN point-to-site VPN gateway.
 module.vwan[0].azurerm_virtual_hub.this | vwan&#8209;sand&#8209;dev&#8209;hub | The Azure Virtual WAN hub.
 module.vwan[0].azurerm_virtual_hub_connection.connections[*] | | The Azure Virtual WAN hub connections to the virtual networks.

--- a/modules/vwan/network.tf
+++ b/modules/vwan/network.tf
@@ -38,6 +38,31 @@ resource "azurerm_point_to_site_vpn_gateway" "this" {
   }
 }
 
+# Routes point-to-site VPN gateway diagnostic logs and metrics to the shared Log Analytics
+# workspace owned by the vnet-shared module. Only the p2svpngateways resource type emits
+# resource logs in this module; the virtual WAN and hub expose platform metrics only.
+resource "azurerm_monitor_diagnostic_setting" "this" {
+  name                       = "Diagnostic Logs"
+  target_resource_id         = azurerm_point_to_site_vpn_gateway.this.id
+  log_analytics_workspace_id = var.log_analytics_workspace_id
+
+  enabled_log {
+    category = "GatewayDiagnosticLog"
+  }
+
+  enabled_log {
+    category = "IKEDiagnosticLog"
+  }
+
+  enabled_log {
+    category = "P2SDiagnosticLog"
+  }
+
+  enabled_metric {
+    category = "AllMetrics"
+  }
+}
+
 resource "azurerm_vpn_server_configuration" "this" {
   name                     = "${module.naming.point_to_site_vpn_gateway.name}-server-config"
   resource_group_name      = var.resource_group_name

--- a/modules/vwan/scripts/Test-Vwan.ps1
+++ b/modules/vwan/scripts/Test-Vwan.ps1
@@ -206,6 +206,59 @@ catch {
     $failed++
 }
 
+# Test 6: Diagnostic setting streams P2S VPN gateway logs and metrics to Log Analytics
+try {
+    $gateways = Get-AzP2sVpnGateway -ResourceGroupName $ResourceGroupName -ErrorAction Stop
+    $gateway = $gateways | Where-Object { $_.VirtualHub.Id -match $VirtualHubName }
+
+    if (-not $gateway) {
+        Write-TestResult $moduleName 'FAIL' "No P2S VPN gateway found associated with Virtual Hub '$VirtualHubName' to verify diagnostic settings"
+        $failed++
+    }
+    else {
+        # Get-AzDiagnosticSetting Log/Metric output properties are changing to List types in
+        # Az.Monitor 7.0.0; query the diagnostic settings via the REST API to stay version-agnostic.
+        $uri = "$($gateway.Id)/providers/Microsoft.Insights/diagnosticSettings?api-version=2021-05-01-preview"
+        $response = Invoke-AzRestMethod -Method GET -Path $uri -ErrorAction Stop
+        $settings = ($response.Content | ConvertFrom-Json).value
+
+        $diagIssues = @()
+
+        $laSetting = $settings | Where-Object { $_.properties.workspaceId } | Select-Object -First 1
+
+        if (-not $laSetting) {
+            $diagIssues += 'no diagnostic setting targeting a Log Analytics workspace found'
+        }
+        else {
+            $enabledLogs = @($laSetting.properties.logs | Where-Object { $_.enabled } | ForEach-Object { $_.category })
+            foreach ($category in @('GatewayDiagnosticLog', 'IKEDiagnosticLog', 'P2SDiagnosticLog')) {
+                if ($enabledLogs -notcontains $category) {
+                    $diagIssues += "log category '$category' is not enabled"
+                }
+            }
+
+            $metricsEnabled = @($laSetting.properties.metrics | Where-Object { $_.enabled -and $_.category -eq 'AllMetrics' })
+            if ($metricsEnabled.Count -eq 0) {
+                $diagIssues += "metric category 'AllMetrics' is not enabled"
+            }
+        }
+
+        if ($diagIssues.Count -eq 0) {
+            Write-TestResult $moduleName 'PASS' ("Diagnostic setting '$($laSetting.name)' streams 'GatewayDiagnosticLog', 'IKEDiagnosticLog', 'P2SDiagnosticLog', and 'AllMetrics' to Log Analytics")
+            $passed++
+        }
+        else {
+            Write-TestResult $moduleName 'FAIL' ("Diagnostic setting issues: " + ($diagIssues -join '; '))
+            $failed++
+        }
+    }
+}
+catch {
+    Write-TestResult $moduleName 'FAIL' "Failed to verify diagnostic setting for the P2S VPN gateway in resource group '$ResourceGroupName'"
+    Write-TestResult $moduleName 'FAIL' "Exception: $_"
+    $failed++
+}
+
 # Summary
 $total = $passed + $failed
 Write-TestResult $moduleName 'SUMMARY' ("Passed: $passed Failed: $failed Total: $total")

--- a/modules/vwan/variables.tf
+++ b/modules/vwan/variables.tf
@@ -29,6 +29,16 @@ variable "key_vault_id" {
   }
 }
 
+variable "log_analytics_workspace_id" {
+  type        = string
+  description = "The resource ID of the existing Log Analytics workspace where point-to-site VPN gateway diagnostic logs and metrics will be sent. Defined in the vnet-shared module."
+
+  validation {
+    condition     = can(regex("^/subscriptions/[0-9a-fA-F-]+/resourceGroups/[a-zA-Z0-9-_()]+/providers/Microsoft.OperationalInsights/workspaces/[a-zA-Z0-9-_()]+$", var.log_analytics_workspace_id))
+    error_message = "Must be a valid Azure Resource ID for a Log Analytics workspace. It should follow the format '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.OperationalInsights/workspaces/{workspaceName}'."
+  }
+}
+
 variable "location" {
   type        = string
   description = "The name of the Azure Region where resources will be provisioned."


### PR DESCRIPTION
## Summary

Integrates the **point-to-site VPN gateway** provisioned by the `vwan` module with the observability framework (Azure Monitor + shared Log Analytics workspace), mirroring the `mysql`/`mssql` precedent (#614 / #606).

## Design note — why P2S gateway only

Virtual WAN has no single "observability" switch; diagnostics are attached **per resource type** via `azurerm_monitor_diagnostic_setting`, and only specific child resources emit resource logs. Per the [Azure Virtual WAN monitoring data reference](https://learn.microsoft.com/azure/virtual-wan/monitor-virtual-wan-reference#resource-logs), within this module:

- `microsoft.network/p2svpngateways` → **resource logs** (`GatewayDiagnosticLog`, `IKEDiagnosticLog`, `P2SDiagnosticLog`) + metrics ✅
- `Microsoft.Network/virtualhubs` → platform **metrics only**, no resource logs
- `azurerm_virtual_wan`, `azurerm_virtual_hub_connection`, `azurerm_vpn_server_configuration` → nothing to emit

So the issue's per-service scope is correct and idiomatic: the P2S gateway is the only log-emitting resource deployed here. (P2S has no `TunnelDiagnosticLog`/`RouteDiagnosticLog` — those are site-to-site only.)

## Changes

- **`modules/vwan/network.tf`** — `azurerm_monitor_diagnostic_setting.this` on the P2S VPN gateway emitting the three P2S log categories + `AllMetrics` to the shared Log Analytics workspace.
- **`modules/vwan/variables.tf`** — new `log_analytics_workspace_id` input (validated resource ID).
- **`main.tf`** — wires `log_analytics_workspace_id` from `module.vnet_shared.resource_ids["log_analytics_workspace"]`.
- **`modules/vwan/scripts/Test-Vwan.ps1`** — new unit test (Test 6) verifying the diagnostic setting streams the expected logs + metrics (queried via REST API to stay Az.Monitor-version-agnostic).
- **`README.md` / `modules/vwan/README.md`** — feature bullet, Secure VPN Access paragraph, variables & resources tables.

## Design notes

- Uses the existing shared Log Analytics workspace, matching the repo convention — no new storage account.
- Diagnostic setting is a control-plane resource, so no public-access barrier wiring is needed.
- Retention inherits the workspace default (per-category retention on diagnostic settings is deprecated in `azurerm`).

## Validation

`./scripts/Invoke-CIChecks.sh terraform markdown powershell` → **No failures** (terraform fmt, tflint, markdownlint, PSScriptAnalyzer all pass).

Fixes #609