### PR TITLE
Bump pinned tflint version from v0.63.1 to v0.64.0

### DIFF
--- a/.github/workflows/ci-terraform.yml
+++ b/.github/workflows/ci-terraform.yml
@@ -82,7 +82,7 @@ jobs:
 
       - uses: terraform-linters/setup-tflint@v6
         with:
-          tflint_version: v0.63.1
+          tflint_version: v0.64.0
 
       # Each directory that contains a .tflint.hcl may pin a different plugin
       # version, so initialize plugins for every config before linting

--- a/scripts/Invoke-CIChecks.sh
+++ b/scripts/Invoke-CIChecks.sh
@@ -23,7 +23,7 @@
 #   links       lychee (offline/internal)   (ci-docs.yml)
 #   actions     actionlint                  (ci-actions.yml)     pin 1.7.12
 #   secrets     gitleaks                    (ci-secrets.yml)     pin 8.30.1
-#   terraform   terraform fmt + tflint      (ci-terraform.yml)   tflint pin v0.63.1
+#   terraform   terraform fmt + tflint      (ci-terraform.yml)   tflint pin v0.64.0
 #
 # A missing tool is reported as SKIPPED (with an install hint) and does not fail
 # the run, but the final summary flags it so you know the gate was not verified.
@@ -113,7 +113,7 @@ check_terraform() {
         done < <(find . -name .tflint.hcl -printf '%h\n' | sort -u)
         run_check tflint tflint --recursive
     else
-        skip tflint "install tflint v0.63.1 (https://github.com/terraform-linters/tflint)"
+        skip tflint "install tflint v0.64.0 (https://github.com/terraform-linters/tflint)"
     fi
 }
 


### PR DESCRIPTION
## Summary

Bumps the pinned tflint version from `v0.63.1` to `v0.64.0` (latest release, 2026-07-17) so CI and local checks track the current tflint.

## Changes

- `.github/workflows/ci-terraform.yml`: `tflint_version: v0.64.0` in the `setup-tflint` step.
- `scripts/Invoke-CIChecks.sh`: updated the header version note and the `skip` install hint to `v0.64.0`.

## Validation

- Ran `./scripts/Invoke-CIChecks.sh terraform actions` locally with tflint v0.64.0 installed — `tflint` and `actions` both PASS. (The unrelated `terraform fmt` finding is on a local, git-ignored `terraform.tfvars` and is not part of this change.)

Fixes #623