### PR TITLE
Bump markdownlint-cli2 pin to 0.23.2 (fixes #624)

### DIFF
--- a/.github/workflows/ci-docs.yml
+++ b/.github/workflows/ci-docs.yml
@@ -62,7 +62,7 @@ jobs:
       # validated against. Globs and ignores come from .markdownlint-cli2.jsonc;
       # rule configuration comes from .markdownlint.jsonc.
       - name: Run markdownlint-cli2
-        run: npx --yes markdownlint-cli2@0.22.1
+        run: npx --yes markdownlint-cli2@0.23.2
 
   lychee:
     name: lychee (internal links)

--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -6,6 +6,8 @@
   "globs": ["**/*.md"],
   "ignores": [
     "node_modules",
+    // Downloaded provider/module cache (git-ignored); not present in CI's fresh checkout.
+    "**/.terraform",
     // Frozen/retired module — excluded from maintenance tooling (see dependabot.yml).
     "extras/modules/retired",
     // Agent tooling configuration, not project documentation.

--- a/scripts/Invoke-CIChecks.sh
+++ b/scripts/Invoke-CIChecks.sh
@@ -19,7 +19,7 @@
 # Available checks (map 1:1 to a CI workflow):
 #   bash        ShellCheck                  (ci-bash.yml)        pin 0.10.0
 #   powershell  PSScriptAnalyzer            (ci-powershell.yml)  pin 1.24.0
-#   markdown    markdownlint-cli2           (ci-docs.yml)        pin 0.22.1
+#   markdown    markdownlint-cli2           (ci-docs.yml)        pin 0.23.2
 #   links       lychee (offline/internal)   (ci-docs.yml)
 #   actions     actionlint                  (ci-actions.yml)     pin 1.7.12
 #   secrets     gitleaks                    (ci-secrets.yml)     pin 8.30.1
@@ -82,7 +82,7 @@ check_powershell() {
 
 check_markdown() {
     have npx || { skip markdown "install Node.js/npm (provides npx)"; return; }
-    run_check markdown npx --yes markdownlint-cli2@0.22.1
+    run_check markdown npx --yes markdownlint-cli2@0.23.2
 }
 
 check_links() {


### PR DESCRIPTION
## Summary

Bumps the pinned `markdownlint-cli2` version from `0.22.1` to `0.23.2` so CI and local checks track the current release, and fixes a local-tooling issue that broke `./scripts/Invoke-CIChecks.sh markdown`.

### CI

- `.github/workflows/ci-docs.yml` — `markdownlint-cli2@0.23.2`.

### Local tooling

- `scripts/Invoke-CIChecks.sh` — updated both the header version note **and** the actual invocation on line 85 (the issue only listed the header note) to `0.23.2`.
- `.markdownlint-cli2.jsonc` — added `**/.terraform` to `ignores`. After `terraform init`, the git-ignored `.terraform` cache contains third-party module READMEs that markdownlint-cli2 was linting locally, producing hundreds of findings and failing the umbrella runner. CI never sees these (fresh checkout, no `.terraform`). This pre-existed the bump (present under 0.22.1 too).

## Validation

`./scripts/Invoke-CIChecks.sh bash actions markdown links` all pass locally with markdownlint-cli2 **v0.23.2**:

```
markdownlint-cli2 v0.23.2 (markdownlint v0.41.1)
Linting: 23 files
Summary: 0 issues in 0 files
...
PASSED:  bash actions markdown links
```

Closes #624.