### PR TITLE
Remove service principal secret from Key Vault (#56)

### DIFF
--- a/README.md
+++ b/README.md
@@ -470,7 +470,6 @@ The variable defaults set in each module can be overridden by customizing the ap
 module "vnet_shared" {
   source = "./modules/vnet-shared"
 
-  arm_client_secret   = var.arm_client_secret
   location            = azurerm_resource_group.this.location
   resource_group_name = azurerm_resource_group.this.name
   tags                = var.tags

--- a/main.tf
+++ b/main.tf
@@ -205,7 +205,6 @@ module "naming" {
 module "vnet_shared" {
   source = "./modules/vnet-shared"
 
-  arm_client_secret   = var.arm_client_secret
   location            = azurerm_resource_group.this.location
   resource_group_name = azurerm_resource_group.this.name
   tags                = local.tags

--- a/modules/vm-mssql-win/locals.tf
+++ b/modules/vm-mssql-win/locals.tf
@@ -7,7 +7,6 @@ locals {
       parameters = [
         "TenantId = '${data.azurerm_client_config.current.tenant_id}';",
         "SubscriptionId = '${data.azurerm_client_config.current.subscription_id}';",
-        "AppId = '${data.azurerm_client_config.current.client_id}';",
         "ResourceGroupName = '${var.resource_group_name}';",
         "KeyVaultName = '${var.key_vault_name}';",
         "Domain = '${var.adds_domain_name}';",

--- a/modules/vm-mssql-win/scripts/Invoke-MssqlConfiguration.ps1
+++ b/modules/vm-mssql-win/scripts/Invoke-MssqlConfiguration.ps1
@@ -16,9 +16,6 @@ param (
     [String]$SubscriptionId,
 
     [Parameter(Mandatory = $true)]
-    [String]$AppId,
-
-    [Parameter(Mandatory = $true)]
     [String]$ResourceGroupName,
 
     [Parameter(Mandatory = $true)]

--- a/modules/vnet-app/compute.tf
+++ b/modules/vnet-app/compute.tf
@@ -99,7 +99,7 @@ resource "azurerm_virtual_machine_extension" "configure_azure_files" {
   type                       = "CustomScriptExtension"
   type_handler_version       = "1.10"
   auto_upgrade_minor_version = true
-  depends_on                 = [azurerm_virtual_machine_extension.join_domain]
+  depends_on                 = [azurerm_virtual_machine_extension.join_domain, azurerm_role_assignment.assignments_vm_win]
 
   settings = jsonencode({
     fileUris = [

--- a/modules/vnet-app/locals.tf
+++ b/modules/vnet-app/locals.tf
@@ -5,9 +5,7 @@ locals {
     orchestrator = {
       name = "Invoke-AzureFilesConfiguration.ps1"
       parameters = [
-        "TenantId = '${data.azurerm_client_config.current.tenant_id}';",
         "SubscriptionId = '${data.azurerm_client_config.current.subscription_id}';",
-        "AppId = '${data.azurerm_client_config.current.client_id}';",
         "ResourceGroupName = '${var.resource_group_name}';",
         "KeyVaultName = '${var.key_vault_name}';",
         "StorageAccountName = '${azurerm_storage_account.this.name}';",
@@ -191,6 +189,18 @@ locals {
       principal_id         = azurerm_windows_virtual_machine.this.identity[0].principal_id
       principal_type       = "ServicePrincipal"
       role_definition_name = "Storage Blob Data Reader"
+      scope                = azurerm_storage_account.this.id
+    }
+    # Required so Set-AzureFilesConfiguration.ps1 can configure identity-based
+    # (Kerberos) access for Azure Files using the VM managed identity:
+    # regenerate/list the storage account 'kerb1' key and enable AD DS
+    # authentication (Microsoft.Storage/storageAccounts/regeneratekey/action,
+    # /listkeys/action, /write). Replaces the former service principal login,
+    # which required the SP secret to be stored in Key Vault.
+    st_account_contributor_vm_win = {
+      principal_id         = azurerm_windows_virtual_machine.this.identity[0].principal_id
+      principal_type       = "ServicePrincipal"
+      role_definition_name = "Storage Account Contributor"
       scope                = azurerm_storage_account.this.id
     }
     # Required for unit-test ARM GETs against Application Insights

--- a/modules/vnet-app/scripts/Invoke-AzureFilesConfiguration.ps1
+++ b/modules/vnet-app/scripts/Invoke-AzureFilesConfiguration.ps1
@@ -1,13 +1,7 @@
 #region parameters
 param (
     [Parameter(Mandatory = $true)]
-    [String]$TenantId,
-
-    [Parameter(Mandatory = $true)]
     [String]$SubscriptionId,
-
-    [Parameter(Mandatory = $true)]
-    [String]$AppId,
 
     [Parameter(Mandatory = $true)]
     [String]$ResourceGroupName,
@@ -140,11 +134,8 @@ Write-ScriptLog "Registering scheduled task '$TaskName' to run '$scriptPath' as 
 
 $commandParamParts = @(
     '$params = @{',
-    "TenantId = '$TenantId'; ", 
     "SubscriptionId = '$SubscriptionId'; ", 
-    "AppId = '$AppId'; ",
     "ResourceGroupName = '$ResourceGroupName'; ",
-    "KeyVaultName = '$KeyVaultName'; ",
     "StorageAccountName = '$StorageAccountName'; ",
     "Domain = '$Domain'",
     '}'

--- a/modules/vnet-app/scripts/Set-AzureFilesConfiguration.ps1
+++ b/modules/vnet-app/scripts/Set-AzureFilesConfiguration.ps1
@@ -1,19 +1,10 @@
 #region parameters
 param(
     [Parameter(Mandatory = $true)]
-    [string]$TenantId,
-
-    [Parameter(Mandatory = $true)]
     [string]$SubscriptionId,
-    
-    [Parameter(Mandatory = $true)]
-    [String]$AppId,
 
     [Parameter(Mandatory = $true)]
     [string]$ResourceGroupName,
-    
-    [Parameter(Mandatory = $true)]
-    [string]$KeyVaultName,
 
     [Parameter(Mandatory = $true)]
     [string]$StorageAccountName,
@@ -48,34 +39,30 @@ Write-Log "Running '$PSCommandPath'..."
 Write-Log "Setting execution policy to 'RemoteSigned'..."
 Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope CurrentUser -Force
 
-# Retrieve secrets from key vault using managed identity
+# Authenticate with the VM managed identity. Keep the context in this process
+# only so no credential material is written to the user profile.
+Write-Log "Disabling Azure PowerShell context autosave for this process..."
+Disable-AzContextAutosave -Scope Process | Out-Null
+
 Write-Log "Logging into Azure using managed identity..."
 
 try {
-    Connect-AzAccount -Identity 
+    Connect-AzAccount -Identity -ErrorAction Stop | Out-Null
 }
 catch {
     Exit-WithError $_
 }
 
-Write-Log "Getting secret '$AppId' from key vault '$KeyVaultName'..."
+Write-Log "Setting default subscription to '$SubscriptionId'..."
 
 try {
-    $appSecret = Get-AzKeyVaultSecret -VaultName $KeyVaultName -Name $AppId -AsPlainText
+    Set-AzContext -Subscription $SubscriptionId | Out-Null
 }
 catch {
     Exit-WithError $_
 }
 
-if ([string]::IsNullOrEmpty($appSecret)) {
-    Exit-WithError "Secret '$AppId' not found in key vault '$KeyVaultName'..."
-}
-
-Write-Log "The length of secret '$AppId' is '$($appSecret.Length)'..."
-
-Disconnect-AzAccount
-
-# Configure identity-based access for storage account using service principal (not managed identity)
+# Configure identity-based access for the storage account using the VM managed identity
 $xDot500Path = "DC=$($Domain.Split('.')[0]),DC=$($Domain.Split('.')[1])"
 $spnValue = "cifs/$StorageAccountName.file.core.windows.net"
 
@@ -95,27 +82,6 @@ else {
     catch {
         Exit-WithError $_
     }
-}
-
-Write-Log "Logging into Azure using service principal id '$AppId'..."
-
-$appSecretSecure = ConvertTo-SecureString $appSecret -AsPlainText -Force
-$spCredential = New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList $AppId, $appSecretSecure
-
-try {
-    Connect-AzAccount -Credential $spCredential -Tenant $TenantId -ServicePrincipal -ErrorAction Stop | Out-Null
-}
-catch {
-    Exit-WithError $_
-}
-
-Write-Log "Setting default subscription to '$SubscriptionId'..."
-
-try {
-    Set-AzContext -Subscription $SubscriptionId | Out-Null
-}
-catch {
-    Exit-WithError $_
 }
 
 Write-Log "Creating 'kerb1' key for storage account '$StorageAccountName' in resource group '$ResourceGroupName'..."

--- a/modules/vnet-shared/README.md
+++ b/modules/vnet-shared/README.md
@@ -88,7 +88,6 @@ admin_password_secret | adminpassword | The name of the key vault secret contain
 admin_password_secret_version | 1 | Increment to create a new admin password secret.
 admin_username | bootstrapadmin | The default admin username used when configuring services.
 admin_username_secret | adminuser | The name of the key vault secret containing the admin username.
-arm_client_secret | | The password for the service principal used for authenticating with Azure. Set interactively or using an environment variable 'TF_VAR_arm_client_secret'.
 location | | The Azure region defined in the root module.
 log_analytics_workspace_retention_days | 30 | The retention period for the new log analytics workspace.
 resource_group_name | | The resource group defined in the root module.
@@ -122,7 +121,6 @@ module.vnet_shared.azurerm_firewall_policy_rule_collection_group.this | fwprcg&#
 module.vnet_shared.azurerm_key_vault.this | kv&#8209;sand&#8209;dev | The Azure Key Vault used to store secrets.
 module.vnet_shared.azurerm_key_vault_secret.adminpassword | adminpassword | Randomly generated admin password used for sandbox VMs and services.
 module.vnet_shared.azurerm_key_vault_secret.adminusername | adminuser | Admin username used for sandbox VMs and services, default is *bootstrapadmin*.
-module.vnet_shared.azurerm_key_vault_secret.spn_password | | The password for the service principal used for authenticating with Azure. The secret name is the same as the AppID / object id.
 module.vnet_shared.azurerm_log_analytics_workspace.this | log&#8209;sand&#8209;dev&#8209;xxx | The Log Analytics workspace used to collect logs and metrics from Azure resources.
 module.vnet_shared.azurerm_monitor_data_collection_endpoint.this | dce&#8209;sand&#8209;dev&#8209;xxx | The data collection endpoint (DCE) for Azure Monitor.
 module.vnet_shared.azurerm_monitor_data_collection_rule.linux | dcr&#8209;sand&#8209;dev&#8209;linux | The data collection rules (DCR) for Linux VMs.

--- a/modules/vnet-shared/main.tf
+++ b/modules/vnet-shared/main.tf
@@ -26,19 +26,6 @@ resource "azurerm_role_assignment" "roles" {
   scope                = azurerm_key_vault.this.id
 }
 
-resource "azurerm_key_vault_secret" "spn_password" {
-  name             = data.azurerm_client_config.current.client_id
-  value_wo         = var.arm_client_secret
-  value_wo_version = var.arm_client_secret_version
-  key_vault_id     = azurerm_key_vault.this.id
-  expiration_date  = timeadd(timestamp(), "8760h")
-  depends_on       = [time_sleep.wait_for_roles]
-
-  lifecycle {
-    ignore_changes = [expiration_date]
-  }
-}
-
 resource "azurerm_key_vault_secret" "adminpassword" {
   name             = var.admin_password_secret
   value_wo         = local.admin_password
@@ -213,7 +200,6 @@ resource "terraform_data" "key_vault_operations_complete" {
   input = {
     secret_adminpassword = azurerm_key_vault_secret.adminpassword.id
     secret_adminusername = azurerm_key_vault_secret.adminusername.id
-    secret_spn_password  = azurerm_key_vault_secret.spn_password.id
   }
 }
 

--- a/modules/vnet-shared/variables.tf
+++ b/modules/vnet-shared/variables.tf
@@ -48,22 +48,6 @@ variable "admin_username_secret" {
   }
 }
 
-variable "arm_client_secret" {
-  type        = string
-  description = "The password for the service principal used for authenticating with Azure. Set interactively or using an environment variable 'TF_VAR_arm_client_secret'."
-  sensitive   = true
-
-  validation {
-    condition     = length(var.arm_client_secret) >= 8
-    error_message = "Must be at least 8 characters long."
-  }
-}
-
-variable "arm_client_secret_version" {
-  type        = number
-  description = "Increment to create new arm_client_secret."
-  default     = 1
-}
 variable "location" {
   type        = string
   description = "The name of the Azure Region where resources will be provisioned."


### PR DESCRIPTION
Closes #56.

## Summary

Azure Files identity-based (Kerberos) access is now configured using the **jumpwin1 managed identity** instead of a service principal (SP) secret login. This eliminates the original `keystore.cache` warning at its source and lets us remove the SP secret from Key Vault entirely.

Previously, `Set-AzureFilesConfiguration.ps1` read the SP secret from Key Vault and called `Connect-AzAccount -ServicePrincipal -Credential`, which caused Az PowerShell to persist the SP secret to `~/.Azure/keystore.cache` (the warning in #56) and materialized the secret as plaintext in memory.

## Changes

- **RBAC:** grant jumpwin1's managed identity `Storage Account Contributor` on the storage account (`modules/vnet-app/locals.tf`). This is the control-plane capability the SP login previously provided — regenerate/list the `kerb1` key and enable AD DS authentication (`.../regeneratekey/action`, `.../listkeys/action`, `.../write`). The config extension now `depends_on` the role assignment.
- **Script:** simplify `Set-AzureFilesConfiguration.ps1` to a single `Connect-AzAccount -Identity` session and add `Disable-AzContextAutosave -Scope Process` so nothing is persisted to the user profile. Removed the SP login block and the now-unused `TenantId`/`AppId`/`KeyVaultName` parameters, plus the matching orchestrator (`Invoke-AzureFilesConfiguration.ps1`) wiring.
- **Key Vault:** remove the now-orphaned `azurerm_key_vault_secret.spn_password`, its `key_vault_operations_complete` barrier signal, and the unused `arm_client_secret` / `arm_client_secret_version` variables from the `vnet-shared` module. The root module still uses `arm_client_secret` for provider auth and `Create-AzSqlDbUser.ps1`.
- **Cleanup:** drop the vestigial, unused `AppId` parameter from the `vm-mssql-win` orchestrator.
- **Docs:** update root and module READMEs.

## Security trade-off (intentional)

jumpwin1's managed identity gains a standing storage control-plane role. This was weighed against the prior design and preferred: the SP approach still allowed a compromised jumpwin1 (which holds standing `Key Vault Secrets User`) to read the SP secret from Key Vault and assume the SP's broader Contributor/Owner rights — a wider latent capability than a storage-scoped role. See #56 for the full discussion.

Note: `Create-AzSqlDbUser.ps1` still performs an SP-secret login, but sources the secret from `TF_VAR_arm_client_secret` (a `protected_parameter`), **not** Key Vault, so it is unaffected. Silencing its own warning with `-Scope Process` is a possible follow-up.

## Validation

- `./scripts/Invoke-CIChecks.sh terraform powershell markdown` — all PASSED.
- `terraform validate` — success.

Full deployment/smoke testing on an applied sandbox is recommended before merge, since the Azure Files configuration path is exercised only at apply time.