### PR TITLE
Make jumplinux2 VM size configurable in rg-devops-iac

### DIFF
--- a/extras/configurations/rg-devops-iac/README.md
+++ b/extras/configurations/rg-devops-iac/README.md
@@ -372,6 +372,7 @@ subscription_id | | The Azure subscription id used to provision resources.
 storage_container_name | tfstate | The name of the storage container to be created in the new storage account.
 tags | | The tags in map format to be used when creating new resources.
 user_object_id | | The object id of the user in Microsoft Entra ID.
+vm_jumpbox_linux_size | `Standard_D2ls_v6` | The size of the jumpbox virtual machine (`jumplinux2`).
 vnet_address_space | 10.0.0.0/16 | The address space in CIDR notation for the new virtual network. The minimum size is /24.
 vnet_name | devops | The name of the new virtual
 

--- a/extras/configurations/rg-devops-iac/main.tf
+++ b/extras/configurations/rg-devops-iac/main.tf
@@ -88,13 +88,14 @@ module "naming" {
 module "vm_jumpbox_linux" {
   source = "./modules/vm-jumpbox-linux"
 
-  enable_public_access = true
-  key_vault_id         = azurerm_key_vault.this.id
-  location             = azurerm_resource_group.this.location
-  resource_group_name  = azurerm_resource_group.this.name
-  storage_account_id   = azurerm_storage_account.this.id
-  subnet_id            = azurerm_subnet.devops.id
-  tags                 = var.tags
+  enable_public_access  = true
+  key_vault_id          = azurerm_key_vault.this.id
+  location              = azurerm_resource_group.this.location
+  resource_group_name   = azurerm_resource_group.this.name
+  storage_account_id    = azurerm_storage_account.this.id
+  subnet_id             = azurerm_subnet.devops.id
+  tags                  = var.tags
+  vm_jumpbox_linux_size = var.vm_jumpbox_linux_size
 
   depends_on = [time_sleep.wait_for_roles]
 }

--- a/extras/configurations/rg-devops-iac/modules/vm-jumpbox-linux/README.md
+++ b/extras/configurations/rg-devops-iac/modules/vm-jumpbox-linux/README.md
@@ -203,7 +203,7 @@ vm_jumpbox_linux_image_publisher | `Canonical` | The publisher for the virtual m
 vm_jumpbox_linux_image_sku | `server` | The SKU of the virtual machine image used to create the VM.
 vm_jumpbox_linux_image_version | `Latest` | The version of the virtual machine image used to create the VM.
 vm_jumpbox_linux_name | jumplinux2 | The name of the VM.
-vm_jumpbox_linux_size | `Standard_B2ls_v2` | The size of the virtual machine.
+vm_jumpbox_linux_size | | The size of the virtual machine.
 vm_jumpbox_linux_storage_account_type | `StandardSSD_LRS` | The storage type to be used for the VM's OS disk. Standard HDD (`Standard_LRS`) is not permitted because Azure is retiring Standard HDD OS disks on September 8, 2028.
 
 ### Module Resources

--- a/extras/configurations/rg-devops-iac/modules/vm-jumpbox-linux/variables.tf
+++ b/extras/configurations/rg-devops-iac/modules/vm-jumpbox-linux/variables.tf
@@ -150,7 +150,7 @@ variable "vm_jumpbox_linux_name" {
 variable "vm_jumpbox_linux_size" {
   type        = string
   description = "The size of the virtual machine"
-  default     = "Standard_B2ls_v2"
+  # default     = "Standard_B2ls_v2"
 
   validation {
     condition     = can(regex("^[a-zA-Z0-9_]+$", var.vm_jumpbox_linux_size))

--- a/extras/configurations/rg-devops-iac/variables.tf
+++ b/extras/configurations/rg-devops-iac/variables.tf
@@ -151,6 +151,17 @@ variable "user_object_id" {
   }
 }
 
+variable "vm_jumpbox_linux_size" {
+  type        = string
+  description = "The size of the virtual machine"
+  default     = "Standard_D2ls_v6"
+
+  validation {
+    condition     = can(regex("^[a-zA-Z0-9_]+$", var.vm_jumpbox_linux_size))
+    error_message = "The 'vm_jumpbox_linux_size' must conform to Azure virtual machine size naming conventions: it can only contain alphanumeric characters and underscores (_). Examples include 'Standard_DS1_v2' or 'Standard_B2ms'."
+  }
+}
+
 variable "vnet_address_space" {
   type        = string
   description = "The address space in CIDR notation for the new virtual network."


### PR DESCRIPTION
## Summary

Exposes `vm_jumpbox_linux_size` as a root-level variable in the standalone `extras/configurations/rg-devops-iac` configuration and passes it through to the `vm-jumpbox-linux` child module, so the `jumplinux2` execution-environment VM size can be configured without editing the module.

## Changes

- Add root `vm_jumpbox_linux_size` variable (default `Standard_D2ls_v6`) with alphanumeric/underscore validation in `variables.tf`.
- Wire it into the `module "vm_jumpbox_linux"` block in `main.tf`.
- Remove the hardcoded default from the child module's `vm_jumpbox_linux_size` so the root value is authoritative.
- Update the root and `vm-jumpbox-linux` module READMEs.

## Scope

Limited to the standalone `extras/configurations/rg-devops-iac` configuration; does not affect the root sandbox modules.

Closes #648