### PR TITLE
fix(mysql): use utf8mb4 charset to stop perpetual testdb replacement

### DIFF
--- a/modules/mysql/main.tf
+++ b/modules/mysql/main.tf
@@ -13,8 +13,11 @@ resource "azurerm_mysql_flexible_database" "this" {
   name                = var.mysql_database_name
   resource_group_name = var.resource_group_name
   server_name         = azurerm_mysql_flexible_server.this.name
-  charset             = "utf8"
-  collation           = "utf8_unicode_ci"
+  # utf8 is a deprecated alias that MySQL 8.0 normalizes to utf8mb3, which causes a
+  # perpetual force-new diff. utf8mb4 is the canonical modern default and is reported
+  # back unchanged by the API.
+  charset   = "utf8mb4"
+  collation = "utf8mb4_unicode_ci"
 }
 
 # Server parameters that must be enabled for the diagnostic categories below to produce data.


### PR DESCRIPTION
Fixes #662

## Problem

`module.mysql[0].azurerm_mysql_flexible_database.this` was destroyed and recreated on **every** `terraform apply`, dropping and re-creating `testdb` each time.

MySQL 8.0 treats `utf8` as a deprecated alias for `utf8mb3` and reports the canonical name back through the API. Terraform read `utf8mb3` / `utf8mb3_unicode_ci` on refresh, compared it against the configured `utf8` / `utf8_unicode_ci`, and — because both attributes are force-new on `azurerm_mysql_flexible_database` — forced replacement. The diff never converged.

## Change

`modules/mysql/main.tf` now sets:

```hcl
charset   = "utf8mb4"
collation = "utf8mb4_unicode_ci"
```

`utf8mb4` is the recommended modern default for MySQL 8.0 (full 4-byte UTF-8) and avoids the deprecated `utf8mb3` alias entirely, so the API reports it back unchanged and plans converge. A short comment records why the deprecated alias must not be reintroduced.

The values remain hardcoded rather than being exposed as module variables, keeping the change minimal.

## Impact / one-time replacement

Applying this change performs a **one-time replacement** of the `testdb` database on existing deployments — the charset change is force-new. That is acceptable for the empty test database shipped with the sandbox, but anyone who has loaded data into `testdb` should back it up before applying. After that single replacement, plans come back clean.

## Validation

- `terraform fmt` and `tflint` pass (`./scripts/Invoke-CIChecks.sh terraform`).
- Not applied against a live sandbox as part of this PR; the deployment-time replacement behavior is described above.

References: [MySQL 8.0 — the `utf8mb3` character set](https://dev.mysql.com/doc/refman/8.0/en/charset-unicode-utf8mb3.html)