### PR TITLE
chore: bump pinned Terraform CLI version to 1.15.9

### DIFF
--- a/.github/workflows/ci-terraform.yml
+++ b/.github/workflows/ci-terraform.yml
@@ -61,8 +61,8 @@ jobs:
 
       - uses: hashicorp/setup-terraform@v4
         with:
-          # Matches required_version (~> 1.15.8) in terraform.tf.
-          terraform_version: 1.15.8
+          # Matches required_version (~> 1.15.9) in terraform.tf.
+          terraform_version: 1.15.9
           terraform_wrapper: false
 
       - name: Check formatting
@@ -129,8 +129,8 @@ jobs:
       - uses: hashicorp/setup-terraform@v4
         if: ${{ needs.changes.outputs.terraform == 'true' }}
         with:
-          # Matches required_version (~> 1.15.8) in terraform.tf.
-          terraform_version: 1.15.8
+          # Matches required_version (~> 1.15.9) in terraform.tf.
+          terraform_version: 1.15.9
           terraform_wrapper: false
 
       # -backend=false downloads providers/initializes modules without

--- a/extras/configurations/rg-devops-iac/modules/vm-jumpbox-linux/terraform.tf
+++ b/extras/configurations/rg-devops-iac/modules/vm-jumpbox-linux/terraform.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 1.15.8"
+  required_version = "~> 1.15.9"
 
   required_providers {
     azurerm = {

--- a/extras/configurations/rg-devops-iac/terraform.tf
+++ b/extras/configurations/rg-devops-iac/terraform.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 1.15.8"
+  required_version = "~> 1.15.9"
 
   required_providers {
     azapi = {

--- a/extras/modules/avd/terraform.tf
+++ b/extras/modules/avd/terraform.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 1.15.8"
+  required_version = "~> 1.15.9"
 
   required_providers {
     azurerm = {

--- a/extras/modules/petstore/terraform.tf
+++ b/extras/modules/petstore/terraform.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 1.15.8"
+  required_version = "~> 1.15.9"
 
   required_providers {
     azurerm = {

--- a/extras/modules/vnet-onprem/terraform.tf
+++ b/extras/modules/vnet-onprem/terraform.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 1.15.8"
+  required_version = "~> 1.15.9"
 
   required_providers {
     azurerm = {

--- a/modules/mssql/terraform.tf
+++ b/modules/mssql/terraform.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 1.15.8"
+  required_version = "~> 1.15.9"
 
   required_providers {
     azurerm = {

--- a/modules/mysql/terraform.tf
+++ b/modules/mysql/terraform.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 1.15.8"
+  required_version = "~> 1.15.9"
 
   required_providers {
     azurerm = {

--- a/modules/vm-jumpbox-linux/terraform.tf
+++ b/modules/vm-jumpbox-linux/terraform.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 1.15.8"
+  required_version = "~> 1.15.9"
 
   required_providers {
     azurerm = {

--- a/modules/vm-mssql-win/terraform.tf
+++ b/modules/vm-mssql-win/terraform.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 1.15.8"
+  required_version = "~> 1.15.9"
 
   required_providers {
     azurerm = {

--- a/modules/vnet-app/terraform.tf
+++ b/modules/vnet-app/terraform.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 1.15.8"
+  required_version = "~> 1.15.9"
 
   required_providers {
     azurerm = {

--- a/modules/vnet-shared/terraform.tf
+++ b/modules/vnet-shared/terraform.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 1.15.8"
+  required_version = "~> 1.15.9"
 
   required_providers {
     azurerm = {

--- a/modules/vwan/terraform.tf
+++ b/modules/vwan/terraform.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 1.15.8"
+  required_version = "~> 1.15.9"
 
   required_providers {
     azurerm = {

--- a/terraform.tf
+++ b/terraform.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 1.15.8"
+  required_version = "~> 1.15.9"
 
   required_providers {
     azuread = {


### PR DESCRIPTION
## Summary
Bumps the pinned Terraform CLI version from `1.15.8` to `1.15.9` across the CI workflow and all module `required_version` constraints, per the automated tool-version drift report.

## Files updated
- `.github/workflows/ci-terraform.yml` (fmt + validate jobs)
- `terraform.tf` (root)
- All module `terraform.tf` files (`modules/*`, `extras/modules/*`, `extras/configurations/rg-devops-iac/*`)

## Validation
- `./scripts/Invoke-CIChecks.sh bash terraform` — passed (ShellCheck, terraform fmt, tflint)

Fixes #677