### PR TITLE
chore(deps): update hashicorp/azurerm requirement to ~> 5.2.0 across all directories

### DIFF
--- a/extras/configurations/rg-devops-iac/modules/vm-jumpbox-linux/terraform.tf
+++ b/extras/configurations/rg-devops-iac/modules/vm-jumpbox-linux/terraform.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 5.1.0"
+      version = "~> 5.2.0"
     }
 
     cloudinit = {

--- a/extras/configurations/rg-devops-iac/terraform.tf
+++ b/extras/configurations/rg-devops-iac/terraform.tf
@@ -9,7 +9,7 @@ terraform {
 
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 5.1.0"
+      version = "~> 5.2.0"
     }
 
     cloudinit = {

--- a/extras/modules/avd/terraform.tf
+++ b/extras/modules/avd/terraform.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 5.1.0"
+      version = "~> 5.2.0"
     }
 
     time = {

--- a/extras/modules/petstore/terraform.tf
+++ b/extras/modules/petstore/terraform.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 5.1.0"
+      version = "~> 5.2.0"
     }
   }
 }

--- a/extras/modules/vnet-onprem/terraform.tf
+++ b/extras/modules/vnet-onprem/terraform.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 5.1.0"
+      version = "~> 5.2.0"
     }
 
     time = {

--- a/modules/mssql/terraform.tf
+++ b/modules/mssql/terraform.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 5.1.0"
+      version = "~> 5.2.0"
     }
 
     random = {

--- a/modules/mysql/terraform.tf
+++ b/modules/mysql/terraform.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 5.1.0"
+      version = "~> 5.2.0"
     }
 
     random = {

--- a/modules/vm-jumpbox-linux/terraform.tf
+++ b/modules/vm-jumpbox-linux/terraform.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 5.1.0"
+      version = "~> 5.2.0"
     }
 
     cloudinit = {

--- a/modules/vm-mssql-win/terraform.tf
+++ b/modules/vm-mssql-win/terraform.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 5.1.0"
+      version = "~> 5.2.0"
     }
 
     random = {

--- a/modules/vnet-app/terraform.tf
+++ b/modules/vnet-app/terraform.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 5.1.0"
+      version = "~> 5.2.0"
     }
 
     random = {

--- a/modules/vnet-shared/terraform.tf
+++ b/modules/vnet-shared/terraform.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 5.1.0"
+      version = "~> 5.2.0"
     }
 
     random = {

--- a/modules/vwan/terraform.tf
+++ b/modules/vwan/terraform.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 5.1.0"
+      version = "~> 5.2.0"
     }
 
     tls = {

--- a/terraform.tf
+++ b/terraform.tf
@@ -14,7 +14,7 @@ terraform {
 
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 5.1.0"
+      version = "~> 5.2.0"
     }
 
     cloudinit = {


### PR DESCRIPTION
Combines the 13 separate dependabot PRs (#664-#676) bumping `hashicorp/azurerm` from `~> 5.1.0` to `~> 5.2.0` in each directory's `terraform.tf`.

**Why combined instead of merging the 13 PRs individually:** Terraform resolves provider version constraints across the entire configuration tree (root + all child modules) at once. `~> 5.1.0` and `~> 5.2.0` are non-overlapping ranges, so merging any single directory's PR alone left the tree with an unsatisfiable combined constraint, causing `terraform init`/`terraform validate` to fail in CI on every one of the 13 PRs. This is the first azurerm release to cross a minor-version boundary since the per-directory dependabot grouping was introduced, so it's the first time this surfaced.

This PR merges all 13 dependabot branches together (clean merge, no conflicts, disjoint files) so every `terraform.tf` moves to `~> 5.2.0` atomically. Verified locally:
- `terraform fmt` / `tflint`: pass
- `terraform init` + `terraform validate` (root, backend disabled): pass
- `terraform init` + `terraform validate` (extras/configurations/rg-devops-iac, backend disabled): pass

Once this merges, the 13 individual dependabot PRs (#664, #665, #666, #667, #668, #669, #670, #671, #672, #673, #674, #675, #676) become redundant and can be closed.