### PR TITLE
fix(vm-jumpbox-linux): retry bootcmd GPG key downloads on DNS resolution race

### DIFF
--- a/modules/vm-jumpbox-linux/scripts/configure-vm-jumpbox-linux.yaml
+++ b/modules/vm-jumpbox-linux/scripts/configure-vm-jumpbox-linux.yaml
@@ -7,12 +7,17 @@ cloud_config_modules:
   - package_update_upgrade_install
   - runcmd
 
+# Note: bootcmd runs very early in boot (before cloud-init's network/DNS readiness is guaranteed), so all
+# external key downloads below use curl's --retry family to ride out transient DNS resolution failures
+# (curl treats "Could not resolve host" as a retryable transient error). Keyring files must exist before
+# apt_configure/package_update_upgrade_install run (cloud_config_modules stage), so this cannot be deferred
+# to runcmd, which only executes later in the modules-final stage.
 bootcmd:
   - test -d /etc/apt/keyrings || install -m 0755 -d /etc/apt/keyrings
-  - test -f /etc/apt/keyrings/docker.asc || (curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc && chmod a+r /etc/apt/keyrings/docker.asc)
-  - test -f /etc/apt/keyrings/hashicorp-archive-keyring.gpg || (wget -O- https://apt.releases.hashicorp.com/gpg | gpg --dearmor | sudo tee /etc/apt/keyrings/hashicorp-archive-keyring.gpg && chmod a+r /etc/apt/keyrings/hashicorp-archive-keyring.gpg)
-  - test -f /etc/apt/keyrings/helm.gpg || (curl -fsSL https://packages.buildkite.com/helm-linux/helm-debian/gpgkey | gpg --dearmor | sudo tee /etc/apt/keyrings/helm.gpg && chmod a+r /etc/apt/keyrings/helm.gpg)
-  - test -f /etc/apt/keyrings/microsoft.gpg || (curl -sLS https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor | sudo tee /etc/apt/keyrings/microsoft.gpg && chmod go+r /etc/apt/keyrings/microsoft.gpg)
+  - test -f /etc/apt/keyrings/docker.asc || (curl -fsSL --retry 6 --retry-all-errors --retry-connrefused --retry-delay 2 https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc && chmod a+r /etc/apt/keyrings/docker.asc)
+  - test -f /etc/apt/keyrings/hashicorp-archive-keyring.gpg || (curl -fsSL --retry 6 --retry-all-errors --retry-connrefused --retry-delay 2 https://apt.releases.hashicorp.com/gpg | gpg --dearmor | sudo tee /etc/apt/keyrings/hashicorp-archive-keyring.gpg && chmod a+r /etc/apt/keyrings/hashicorp-archive-keyring.gpg)
+  - test -f /etc/apt/keyrings/helm.gpg || (curl -fsSL --retry 6 --retry-all-errors --retry-connrefused --retry-delay 2 https://packages.buildkite.com/helm-linux/helm-debian/gpgkey | gpg --dearmor | sudo tee /etc/apt/keyrings/helm.gpg && chmod a+r /etc/apt/keyrings/helm.gpg)
+  - test -f /etc/apt/keyrings/microsoft.gpg || (curl -fsSL --retry 6 --retry-all-errors --retry-connrefused --retry-delay 2 https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor | sudo tee /etc/apt/keyrings/microsoft.gpg && chmod go+r /etc/apt/keyrings/microsoft.gpg)
 
 apt:
   sources:


### PR DESCRIPTION
## Summary

Fixes #681.

On boot, jumplinux1's `bootcmd` fetches 4 apt-repo GPG keyrings (docker, hashicorp, helm, microsoft) before DNS is guaranteed to be ready. The docker `curl` call was intermittently losing this race (`curl: (6) Could not resolve host: download.docker.com`), leaving `/etc/apt/keyrings/docker.asc` missing. This broke GPG verification for the docker apt source and failed the whole `package_update_upgrade_install` step for docker-related packages, causing a cascading unit-test failure (`cloud-init status=error`, `docker not found`).

Root cause was confirmed via cloud-init logs and manual repro on `jumplinux1` — Docker's signing key has **not** rotated; this is a transient boot-time DNS timing issue, likely aggravated by this VM's egress routing through Azure Firewall/UDR with an AD DS DNS forwarder.

## Fix

Add curl's `--retry --retry-delay --retry-connrefused --retry-all-errors` flags to all 4 `bootcmd` key-download commands (also converting the hashicorp key fetch from `wget` to `curl` for consistency). Empirically verified (on jumplinux1's actual curl 8.5.0) that curl retries on DNS resolution failures despite the man page only listing HTTP/FTP transient codes.

Moving these commands to `runcmd` was considered and rejected: `runcmd` only *writes* its script during the `modules-config` stage and always *executes* later in `modules-final`, which runs after `apt_configure`/`package_update_upgrade_install`. Deferring would break keyrings for all 4 apt sources at once (terraform, helm, azure-cli, docker, powershell, samba, etc.) instead of just docker.

## Validation

- `terraform fmt`, `tflint`, `terraform validate`, and `./scripts/Invoke-CIChecks.sh` all pass (the only reported failure, a pre-existing PSScriptAnalyzer warning in `make.ps1`, is unrelated to this change — no `.ps1` files were touched).
- Reproduced live using the repo's Scenario 3 pattern: disabled/re-enabled `enable_module_vm_jumpbox_linux` to force jumplinux1 re-provisioning against a live sandbox.
- Post-fix: `cloud-init status` = `done`, docker installed, all 4 keyrings present.
- `Invoke-UnitTests.ps1 -Module vm_jumpbox_linux -Integration`: **14/14 passed** (previously 11/13 for this module before the fix).