### PR TITLE
chore(deps): update azurerm provider to ~> 5.3.0

### DIFF
--- a/.github/workflows/ci-terraform.yml
+++ b/.github/workflows/ci-terraform.yml
@@ -61,8 +61,8 @@ jobs:
 
       - uses: hashicorp/setup-terraform@v4
         with:
-          # Matches required_version (~> 1.15.9) in terraform.tf.
-          terraform_version: 1.15.9
+          # Matches required_version (~> 1.16.0) in terraform.tf.
+          terraform_version: 1.16.0
           terraform_wrapper: false
 
       - name: Check formatting
@@ -129,8 +129,8 @@ jobs:
       - uses: hashicorp/setup-terraform@v4
         if: ${{ needs.changes.outputs.terraform == 'true' }}
         with:
-          # Matches required_version (~> 1.15.9) in terraform.tf.
-          terraform_version: 1.15.9
+          # Matches required_version (~> 1.16.0) in terraform.tf.
+          terraform_version: 1.16.0
           terraform_wrapper: false
 
       # -backend=false downloads providers/initializes modules without

--- a/extras/configurations/rg-devops-iac/modules/vm-jumpbox-linux/terraform.tf
+++ b/extras/configurations/rg-devops-iac/modules/vm-jumpbox-linux/terraform.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 1.15.9"
+  required_version = "~> 1.16.0"
 
   required_providers {
     azurerm = {

--- a/extras/configurations/rg-devops-iac/modules/vm-jumpbox-linux/terraform.tf
+++ b/extras/configurations/rg-devops-iac/modules/vm-jumpbox-linux/terraform.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 5.2.0"
+      version = "~> 5.3.0"
     }
 
     cloudinit = {

--- a/extras/configurations/rg-devops-iac/terraform.tf
+++ b/extras/configurations/rg-devops-iac/terraform.tf
@@ -9,7 +9,7 @@ terraform {
 
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 5.2.0"
+      version = "~> 5.3.0"
     }
 
     cloudinit = {

--- a/extras/configurations/rg-devops-iac/terraform.tf
+++ b/extras/configurations/rg-devops-iac/terraform.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 1.15.9"
+  required_version = "~> 1.16.0"
 
   required_providers {
     azapi = {

--- a/extras/modules/avd/terraform.tf
+++ b/extras/modules/avd/terraform.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 5.2.0"
+      version = "~> 5.3.0"
     }
 
     time = {

--- a/extras/modules/avd/terraform.tf
+++ b/extras/modules/avd/terraform.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 1.15.9"
+  required_version = "~> 1.16.0"
 
   required_providers {
     azurerm = {

--- a/extras/modules/petstore/terraform.tf
+++ b/extras/modules/petstore/terraform.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 5.2.0"
+      version = "~> 5.3.0"
     }
   }
 }

--- a/extras/modules/petstore/terraform.tf
+++ b/extras/modules/petstore/terraform.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 1.15.9"
+  required_version = "~> 1.16.0"
 
   required_providers {
     azurerm = {

--- a/extras/modules/vnet-onprem/terraform.tf
+++ b/extras/modules/vnet-onprem/terraform.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 5.2.0"
+      version = "~> 5.3.0"
     }
 
     time = {

--- a/extras/modules/vnet-onprem/terraform.tf
+++ b/extras/modules/vnet-onprem/terraform.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 1.15.9"
+  required_version = "~> 1.16.0"
 
   required_providers {
     azurerm = {

--- a/modules/mssql/terraform.tf
+++ b/modules/mssql/terraform.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 5.2.0"
+      version = "~> 5.3.0"
     }
 
     random = {

--- a/modules/mssql/terraform.tf
+++ b/modules/mssql/terraform.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 1.15.9"
+  required_version = "~> 1.16.0"
 
   required_providers {
     azurerm = {

--- a/modules/mysql/terraform.tf
+++ b/modules/mysql/terraform.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 5.2.0"
+      version = "~> 5.3.0"
     }
 
     random = {

--- a/modules/mysql/terraform.tf
+++ b/modules/mysql/terraform.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 1.15.9"
+  required_version = "~> 1.16.0"
 
   required_providers {
     azurerm = {

--- a/modules/vm-jumpbox-linux/terraform.tf
+++ b/modules/vm-jumpbox-linux/terraform.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 1.15.9"
+  required_version = "~> 1.16.0"
 
   required_providers {
     azurerm = {

--- a/modules/vm-jumpbox-linux/terraform.tf
+++ b/modules/vm-jumpbox-linux/terraform.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 5.2.0"
+      version = "~> 5.3.0"
     }
 
     cloudinit = {

--- a/modules/vm-mssql-win/terraform.tf
+++ b/modules/vm-mssql-win/terraform.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 5.2.0"
+      version = "~> 5.3.0"
     }
 
     random = {

--- a/modules/vm-mssql-win/terraform.tf
+++ b/modules/vm-mssql-win/terraform.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 1.15.9"
+  required_version = "~> 1.16.0"
 
   required_providers {
     azurerm = {

--- a/modules/vnet-app/terraform.tf
+++ b/modules/vnet-app/terraform.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 5.2.0"
+      version = "~> 5.3.0"
     }
 
     random = {

--- a/modules/vnet-app/terraform.tf
+++ b/modules/vnet-app/terraform.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 1.15.9"
+  required_version = "~> 1.16.0"
 
   required_providers {
     azurerm = {

--- a/modules/vnet-shared/terraform.tf
+++ b/modules/vnet-shared/terraform.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 5.2.0"
+      version = "~> 5.3.0"
     }
 
     random = {

--- a/modules/vnet-shared/terraform.tf
+++ b/modules/vnet-shared/terraform.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 1.15.9"
+  required_version = "~> 1.16.0"
 
   required_providers {
     azurerm = {

--- a/modules/vwan/terraform.tf
+++ b/modules/vwan/terraform.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 1.15.9"
+  required_version = "~> 1.16.0"
 
   required_providers {
     azurerm = {

--- a/modules/vwan/terraform.tf
+++ b/modules/vwan/terraform.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 5.2.0"
+      version = "~> 5.3.0"
     }
 
     tls = {

--- a/terraform.tf
+++ b/terraform.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 1.15.9"
+  required_version = "~> 1.16.0"
 
   required_providers {
     azuread = {

--- a/terraform.tf
+++ b/terraform.tf
@@ -14,7 +14,7 @@ terraform {
 
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 5.2.0"
+      version = "~> 5.3.0"
     }
 
     cloudinit = {


### PR DESCRIPTION
## Summary

Consolidates the Dependabot updates bumping the `hashicorp/azurerm` provider constraint from `~> 5.2.0` to `~> 5.3.0` across the root configuration, all base modules, all extras modules, and the `rg-devops-iac` standalone configuration. Also bumps the Terraform CLI version used by the Terraform CI workflow.

### Changed files

- `terraform.tf` (root)
- `modules/{mssql,mysql,vm-jumpbox-linux,vm-mssql-win,vnet-app,vnet-shared,vwan}/terraform.tf`
- `extras/modules/{avd,petstore,vnet-onprem}/terraform.tf`
- `extras/configurations/rg-devops-iac/terraform.tf` and its `modules/vm-jumpbox-linux/terraform.tf`
- `.github/workflows/ci-terraform.yml` (Terraform CLI version bump)

## Validation

**Static analysis** — `./scripts/Invoke-CIChecks.sh terraform actions`: `terraform fmt`, `tflint`, and `actionlint` all PASSED, no failures.

**Full sandbox deployment** — a complete sandbox was deployed from this branch with all base modules enabled (`vnet_shared`, `vnet_app`, `vm_jumpbox_linux`, `vm_mssql_win`, `mssql`, `mysql`, `vwan`); extras were left disabled.

- `terraform init` / `validate` / `plan` clean
- `terraform apply`: **250 added, 0 changed, 0 destroyed** (~97 min), no errors

**Automated tests** — `pwsh -File ./scripts/Invoke-UnitTests.ps1` (all modules, unit + integration) with all VMs confirmed running:

```
RESULT: PASS
Overall: Passed=109 Failed=0 Total=109

[PASS] vnet-shared: Passed=9  Failed=0
[PASS] vnet-app: Passed=20 Failed=0
[PASS] vm-jumpbox-linux: Passed=13 Failed=0
[PASS] vm-mssql-win: Passed=25 Failed=0
[PASS] mssql: Passed=6  Failed=0
[PASS] mysql: Passed=6  Failed=0
[PASS] vnet-shared: Passed=2  Failed=0
[PASS] vwan: Passed=6  Failed=0
[PASS] integration: SSH: jumpwin1 -> jumplinux1: Passed=1  Failed=0
[PASS] integration: SQL: jumpwin1 -> mssqlwin1: Passed=1  Failed=0
[PASS] integration: Azure SQL: jumpwin1 -> testdb: Passed=4  Failed=0
[PASS] integration: MySQL: jumpwin1 -> mysql: Passed=4  Failed=0
[PASS] integration: P2S VPN: local -> sandbox endpoints: Passed=12 Failed=0
```

No regressions observed with the `azurerm` 5.3.0 provider.