### PR TITLE
Release: merge vnext into main

### DIFF
--- a/.github/workflows/ci-terraform.yml
+++ b/.github/workflows/ci-terraform.yml
@@ -61,8 +61,8 @@ jobs:
 
       - uses: hashicorp/setup-terraform@v4
         with:
-          # Matches required_version (~> 1.15.9) in terraform.tf.
-          terraform_version: 1.15.9
+          # Matches required_version (~> 1.16.0) in terraform.tf.
+          terraform_version: 1.16.0
           terraform_wrapper: false
 
       - name: Check formatting
@@ -129,8 +129,8 @@ jobs:
       - uses: hashicorp/setup-terraform@v4
         if: ${{ needs.changes.outputs.terraform == 'true' }}
         with:
-          # Matches required_version (~> 1.15.9) in terraform.tf.
-          terraform_version: 1.15.9
+          # Matches required_version (~> 1.16.0) in terraform.tf.
+          terraform_version: 1.16.0
           terraform_wrapper: false
 
       # -backend=false downloads providers/initializes modules without

--- a/extras/configurations/rg-devops-iac/modules/vm-jumpbox-linux/terraform.tf
+++ b/extras/configurations/rg-devops-iac/modules/vm-jumpbox-linux/terraform.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 1.15.9"
+  required_version = "~> 1.16.0"
 
   required_providers {
     azurerm = {

--- a/extras/configurations/rg-devops-iac/modules/vm-jumpbox-linux/terraform.tf
+++ b/extras/configurations/rg-devops-iac/modules/vm-jumpbox-linux/terraform.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 5.2.0"
+      version = "~> 5.3.0"
     }
 
     cloudinit = {

--- a/extras/configurations/rg-devops-iac/terraform.tf
+++ b/extras/configurations/rg-devops-iac/terraform.tf
@@ -9,7 +9,7 @@ terraform {
 
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 5.2.0"
+      version = "~> 5.3.0"
     }
 
     cloudinit = {

--- a/extras/configurations/rg-devops-iac/terraform.tf
+++ b/extras/configurations/rg-devops-iac/terraform.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 1.15.9"
+  required_version = "~> 1.16.0"
 
   required_providers {
     azapi = {

--- a/extras/modules/avd/terraform.tf
+++ b/extras/modules/avd/terraform.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 5.2.0"
+      version = "~> 5.3.0"
     }
 
     time = {

--- a/extras/modules/avd/terraform.tf
+++ b/extras/modules/avd/terraform.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 1.15.9"
+  required_version = "~> 1.16.0"
 
   required_providers {
     azurerm = {

--- a/extras/modules/petstore/terraform.tf
+++ b/extras/modules/petstore/terraform.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 5.2.0"
+      version = "~> 5.3.0"
     }
   }
 }

--- a/extras/modules/petstore/terraform.tf
+++ b/extras/modules/petstore/terraform.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 1.15.9"
+  required_version = "~> 1.16.0"
 
   required_providers {
     azurerm = {

--- a/extras/modules/vnet-onprem/terraform.tf
+++ b/extras/modules/vnet-onprem/terraform.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 5.2.0"
+      version = "~> 5.3.0"
     }
 
     time = {

--- a/extras/modules/vnet-onprem/terraform.tf
+++ b/extras/modules/vnet-onprem/terraform.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 1.15.9"
+  required_version = "~> 1.16.0"
 
   required_providers {
     azurerm = {

--- a/modules/mssql/terraform.tf
+++ b/modules/mssql/terraform.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 5.2.0"
+      version = "~> 5.3.0"
     }
 
     random = {

--- a/modules/mssql/terraform.tf
+++ b/modules/mssql/terraform.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 1.15.9"
+  required_version = "~> 1.16.0"
 
   required_providers {
     azurerm = {

--- a/modules/mysql/terraform.tf
+++ b/modules/mysql/terraform.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 5.2.0"
+      version = "~> 5.3.0"
     }
 
     random = {

--- a/modules/mysql/terraform.tf
+++ b/modules/mysql/terraform.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 1.15.9"
+  required_version = "~> 1.16.0"
 
   required_providers {
     azurerm = {

--- a/modules/vm-jumpbox-linux/terraform.tf
+++ b/modules/vm-jumpbox-linux/terraform.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 1.15.9"
+  required_version = "~> 1.16.0"
 
   required_providers {
     azurerm = {

--- a/modules/vm-jumpbox-linux/terraform.tf
+++ b/modules/vm-jumpbox-linux/terraform.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 5.2.0"
+      version = "~> 5.3.0"
     }
 
     cloudinit = {

--- a/modules/vm-mssql-win/terraform.tf
+++ b/modules/vm-mssql-win/terraform.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 5.2.0"
+      version = "~> 5.3.0"
     }
 
     random = {

--- a/modules/vm-mssql-win/terraform.tf
+++ b/modules/vm-mssql-win/terraform.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 1.15.9"
+  required_version = "~> 1.16.0"
 
   required_providers {
     azurerm = {

--- a/modules/vnet-app/terraform.tf
+++ b/modules/vnet-app/terraform.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 5.2.0"
+      version = "~> 5.3.0"
     }
 
     random = {

--- a/modules/vnet-app/terraform.tf
+++ b/modules/vnet-app/terraform.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 1.15.9"
+  required_version = "~> 1.16.0"
 
   required_providers {
     azurerm = {

--- a/modules/vnet-shared/terraform.tf
+++ b/modules/vnet-shared/terraform.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 5.2.0"
+      version = "~> 5.3.0"
     }
 
     random = {

--- a/modules/vnet-shared/terraform.tf
+++ b/modules/vnet-shared/terraform.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 1.15.9"
+  required_version = "~> 1.16.0"
 
   required_providers {
     azurerm = {

--- a/modules/vwan/terraform.tf
+++ b/modules/vwan/terraform.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 1.15.9"
+  required_version = "~> 1.16.0"
 
   required_providers {
     azurerm = {

--- a/modules/vwan/terraform.tf
+++ b/modules/vwan/terraform.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 5.2.0"
+      version = "~> 5.3.0"
     }
 
     tls = {

--- a/terraform.tf
+++ b/terraform.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 1.15.9"
+  required_version = "~> 1.16.0"
 
   required_providers {
     azuread = {

--- a/terraform.tf
+++ b/terraform.tf
@@ -14,7 +14,7 @@ terraform {
 
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 5.2.0"
+      version = "~> 5.3.0"
     }
 
     cloudinit = {


### PR DESCRIPTION
## Purpose

* Update the `hashicorp/azurerm` provider constraint from `~> 5.2.0` to `~> 5.3.0` across the root configuration, all base modules (`mssql`, `mysql`, `vm-jumpbox-linux`, `vm-mssql-win`, `vnet-app`, `vnet-shared`, `vwan`), all extras modules (`avd`, `petstore`, `vnet-onprem`), and the standalone `rg-devops-iac` configuration.
* Update the Terraform `required_version` from `~> 1.15.9` to `~> 1.16.0` in the root `terraform.tf`, and bump the matching pinned `terraform_version` (1.15.9 → 1.16.0) in both jobs of the Terraform CI workflow so CI stays aligned with the required version.

## Does this introduce a breaking change?

```plaintext
[ ] Yes
[x] No
```

## Pull Request Type

What kind of change does this Pull Request introduce?

```plaintext
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[x] Other... Please describe: Dependency maintenance release (Terraform provider and CLI version bumps) merged from vnext into main.
```

## How to Test

* Provision a new sandbox environment
* Run unit tests

This was already done for this change set:

* All base modules enabled (`vnet_shared`, `vnet_app`, `vm_jumpbox_linux`, `vm_mssql_win`, `mssql`, `mysql`, `vwan`); extras modules left disabled.
* `terraform init`, `terraform validate`, and `terraform plan` completed cleanly.
* `terraform apply` completed successfully: **250 added, 0 changed, 0 destroyed** (~97 minutes), no errors.
* All VMs confirmed running, then `pwsh -File ./scripts/Invoke-UnitTests.ps1` was run for all installed modules (unit + integration tests).

## What to Check

Verify that the following are valid

* Unit tests should all pass.

Results from the validation run — **RESULT: PASS, Overall: Passed=109 Failed=0 Total=109**:

```plaintext
[PASS] vnet-shared: Passed=9  Failed=0
[PASS] vnet-app: Passed=20 Failed=0
[PASS] vm-jumpbox-linux: Passed=13 Failed=0
[PASS] vm-mssql-win: Passed=25 Failed=0
[PASS] mssql: Passed=6  Failed=0
[PASS] mysql: Passed=6  Failed=0
[PASS] vnet-shared: Passed=2  Failed=0
[PASS] vwan: Passed=6  Failed=0
[PASS] integration: SSH: jumpwin1 -> jumplinux1: Passed=1  Failed=0
[PASS] integration: SQL: jumpwin1 -> mssqlwin1: Passed=1  Failed=0
[PASS] integration: Azure SQL: jumpwin1 -> testdb: Passed=4  Failed=0
[PASS] integration: MySQL: jumpwin1 -> mysql: Passed=4  Failed=0
[PASS] integration: P2S VPN: local -> sandbox endpoints: Passed=12 Failed=0
```

Also verify:

* Static analysis is clean — `./scripts/Invoke-CIChecks.sh terraform actions` reported `terraform fmt`, `tflint`, and `actionlint` all PASSED with no failures.
* The pinned `terraform_version` in `.github/workflows/ci-terraform.yml` matches `required_version` in the root `terraform.tf` (both `1.16.0` / `~> 1.16.0`).

## Other Information

* Changed files (14): `terraform.tf`, `modules/{mssql,mysql,vm-jumpbox-linux,vm-mssql-win,vnet-app,vnet-shared,vwan}/terraform.tf`, `extras/modules/{avd,petstore,vnet-onprem}/terraform.tf`, `extras/configurations/rg-devops-iac/terraform.tf`, `extras/configurations/rg-devops-iac/modules/vm-jumpbox-linux/terraform.tf`, and `.github/workflows/ci-terraform.yml`.
* Included PR: #699 (azurerm `~> 5.3.0` consolidation and Terraform CLI version bump).
* **Merge strategy:** this release PR must be merged with a **regular merge commit (no squash)** so individual commits and branch lineage are preserved on `main`, per CONTRIBUTING.md.
